### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/Tests/UriImmutableTest.php
+++ b/Tests/UriImmutableTest.php
@@ -264,26 +264,26 @@ class UriImmuteableTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the isSSL method.
+	 * Test the isSsl method.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
-	 * @covers  Joomla\Uri\UriImmutable::isSSL
+	 * @covers  Joomla\Uri\UriImmutable::isSsl
 	 */
-	public function testIsSSL()
+	public function testisSsl()
 	{
 		$this->object = new UriImmutable('https://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment');
 
 		$this->assertThat(
-			$this->object->isSSL(),
+			$this->object->isSsl(),
 			$this->equalTo(true)
 		);
 
 		$this->object = new UriImmutable('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment');
 
 		$this->assertThat(
-			$this->object->isSSL(),
+			$this->object->isSsl(),
 			$this->equalTo(false)
 		);
 	}

--- a/Tests/UriTest.php
+++ b/Tests/UriTest.php
@@ -563,26 +563,26 @@ class UriTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the isSSL method.
+	 * Test the isSsl method.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
-	 * @covers  Joomla\Uri\Uri::isSSL
+	 * @covers  Joomla\Uri\Uri::isSsl
 	 */
-	public function testIsSSL()
+	public function testisSsl()
 	{
 		$object = new Uri('https://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment');
 
 		$this->assertThat(
-			$object->isSSL(),
+			$object->isSsl(),
 			$this->equalTo(true)
 		);
 
 		$object = new Uri('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment');
 
 		$this->assertThat(
-			$object->isSSL(),
+			$object->isSsl(),
 			$this->equalTo(false)
 		);
 	}

--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -290,7 +290,7 @@ abstract class AbstractUri implements UriInterface
 	 *
 	 * @since   1.0
 	 */
-	public function isSSL()
+	public function isSsl()
 	{
 		return $this->getScheme() == 'https' ? true : false;
 	}

--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -147,5 +147,5 @@ interface UriInterface
 	 *
 	 * @since   1.0
 	 */
-	public function isSSL();
+	public function isSsl();
 }


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).