### PR TITLE
Allow the UriInterface::toString function to accept a list of strinngs or an integer

### DIFF
--- a/Tests/UriImmutableTest.php
+++ b/Tests/UriImmutableTest.php
@@ -80,14 +80,9 @@ class UriImmuteableTest extends TestCase
 	{
 		$classname = get_class($this->object);
 
-		// The next 4 tested functions should generate equivalent results
+		// The next 2 tested functions should generate equivalent results
 		$this->assertThat(
 			$this->object->toString(),
-			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
-		);
-
-		$this->assertThat(
-			$this->object->toString($classname::ALL),
 			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
 		);
 
@@ -96,21 +91,9 @@ class UriImmuteableTest extends TestCase
 			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
 		);
 
-		// The next 3 tested functions should generate equivalent results
-		$this->assertThat(
-			$this->object->toString($classname::SCHEME),
-			$this->equalTo('http://')
-		);
-
 		$this->assertThat(
 			$this->object->toString(array('scheme')),
 			$this->equalTo('http://')
-		);
-
-		// The next 3 tested functions should generate equivalent results
-		$this->assertThat(
-			$this->object->toString($classname::HOST | $classname::PORT),
-			$this->equalTo('www.example.com:80')
 		);
 
 		$this->assertThat(
@@ -118,25 +101,51 @@ class UriImmuteableTest extends TestCase
 			$this->equalTo('www.example.com:80')
 		);
 
-		// The next 3 tested functions should generate equivalent results
-		$this->assertThat(
-			$this->object->toString($classname::PATH | $classname::QUERY | $classname::FRAGMENT),
-			$this->equalTo('/path/file.html?var=value#fragment')
-		);
-
 		$this->assertThat(
 			$this->object->toString(array('path', 'query', 'fragment')),
 			$this->equalTo('/path/file.html?var=value#fragment')
 		);
 
-		// The next 3 tested functions should generate equivalent results
 		$this->assertThat(
-			$this->object->toString($classname::ALL & ~$classname::SCHEME),
+			$this->object->toString(array('user', 'pass', 'host', 'port', 'path', 'query', 'fragment')),
 			$this->equalTo('someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+	}
+
+	/**
+	 * Test the render method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @covers  Joomla\Uri\UriImmutable::render
+	 */
+	public function testRender()
+	{
+		$classname = get_class($this->object);
+
+		$this->assertThat(
+			$this->object->render($classname::ALL),
+			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
 		);
 
 		$this->assertThat(
-			$this->object->toString(array('user', 'pass', 'host', 'port', 'path', 'query', 'fragment')),
+			$this->object->render($classname::SCHEME),
+			$this->equalTo('http://')
+		);
+
+		$this->assertThat(
+			$this->object->render($classname::HOST | $classname::PORT),
+			$this->equalTo('www.example.com:80')
+		);
+
+		$this->assertThat(
+			$this->object->render($classname::PATH | $classname::QUERY | $classname::FRAGMENT),
+			$this->equalTo('/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->render($classname::ALL & ~$classname::SCHEME),
 			$this->equalTo('someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
 		);
 	}

--- a/Tests/UriImmutableTest.php
+++ b/Tests/UriImmutableTest.php
@@ -78,9 +78,91 @@ class UriImmuteableTest extends TestCase
 	 */
 	public function testToString()
 	{
+		$classname = get_class($this->object);
+
+		// The next 4 tested functions should generate equivalent results
 		$this->assertThat(
 			$this->object->toString(),
 			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->toString($classname::ALL),
+			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->toString('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment'),
+			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->toString(array('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment')),
+			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+
+		// The next 3 tested functions should generate equivalent results
+		$this->assertThat(
+			$this->object->toString($classname::SCHEME),
+			$this->equalTo('http://')
+		);
+
+		$this->assertThat(
+			$this->object->toString('scheme'),
+			$this->equalTo('http://')
+		);
+
+		$this->assertThat(
+			$this->object->toString(array('scheme')),
+			$this->equalTo('http://')
+		);
+
+		// The next 3 tested functions should generate equivalent results
+		$this->assertThat(
+			$this->object->toString($classname::HOST | $classname::PORT),
+			$this->equalTo('www.example.com:80')
+		);
+
+		$this->assertThat(
+			$this->object->toString('host', 'port'),
+			$this->equalTo('www.example.com:80')
+		);
+
+		$this->assertThat(
+			$this->object->toString(array('host', 'port')),
+			$this->equalTo('www.example.com:80')
+		);
+
+		// The next 3 tested functions should generate equivalent results
+		$this->assertThat(
+			$this->object->toString($classname::PATH | $classname::QUERY | $classname::FRAGMENT),
+			$this->equalTo('/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->toString('path', 'query', 'fragment'),
+			$this->equalTo('/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->toString(array('path', 'query', 'fragment')),
+			$this->equalTo('/path/file.html?var=value#fragment')
+		);
+
+		// The next 3 tested functions should generate equivalent results
+		$this->assertThat(
+			$this->object->toString($classname::ALL & ~$classname::SCHEME),
+			$this->equalTo('someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->toString('user', 'pass', 'host', 'port', 'path', 'query', 'fragment'),
+			$this->equalTo('someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->toString(array('user', 'pass', 'host', 'port', 'path', 'query', 'fragment')),
+			$this->equalTo('someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
 		);
 	}
 

--- a/Tests/UriImmutableTest.php
+++ b/Tests/UriImmutableTest.php
@@ -92,11 +92,6 @@ class UriImmuteableTest extends TestCase
 		);
 
 		$this->assertThat(
-			$this->object->toString('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment'),
-			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
-		);
-
-		$this->assertThat(
 			$this->object->toString(array('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment')),
 			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
 		);
@@ -104,11 +99,6 @@ class UriImmuteableTest extends TestCase
 		// The next 3 tested functions should generate equivalent results
 		$this->assertThat(
 			$this->object->toString($classname::SCHEME),
-			$this->equalTo('http://')
-		);
-
-		$this->assertThat(
-			$this->object->toString('scheme'),
 			$this->equalTo('http://')
 		);
 
@@ -124,11 +114,6 @@ class UriImmuteableTest extends TestCase
 		);
 
 		$this->assertThat(
-			$this->object->toString('host', 'port'),
-			$this->equalTo('www.example.com:80')
-		);
-
-		$this->assertThat(
 			$this->object->toString(array('host', 'port')),
 			$this->equalTo('www.example.com:80')
 		);
@@ -140,11 +125,6 @@ class UriImmuteableTest extends TestCase
 		);
 
 		$this->assertThat(
-			$this->object->toString('path', 'query', 'fragment'),
-			$this->equalTo('/path/file.html?var=value#fragment')
-		);
-
-		$this->assertThat(
 			$this->object->toString(array('path', 'query', 'fragment')),
 			$this->equalTo('/path/file.html?var=value#fragment')
 		);
@@ -152,11 +132,6 @@ class UriImmuteableTest extends TestCase
 		// The next 3 tested functions should generate equivalent results
 		$this->assertThat(
 			$this->object->toString($classname::ALL & ~$classname::SCHEME),
-			$this->equalTo('someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
-		);
-
-		$this->assertThat(
-			$this->object->toString('user', 'pass', 'host', 'port', 'path', 'query', 'fragment'),
 			$this->equalTo('someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
 		);
 

--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -110,7 +110,7 @@ abstract class AbstractUri implements UriInterface
 	/**
 	 * Returns full uri string.
 	 *
-	 * @param   mixed  $parts  An integer, a list of strings, or an array of strings specifying the parts to render.
+	 * @param   mixed  $parts  An integer, or an array of strings specifying the parts to render.
 	 *
 	 * @return  string  The rendered URI string.
 	 *
@@ -118,11 +118,6 @@ abstract class AbstractUri implements UriInterface
 	 */
 	public function toString($parts = self::ALL)
 	{
-		if (is_string($parts))
-		{
-			$parts = func_get_args();
-		}
-
 		if (is_array($parts))
 		{
 			$realParts = 0;

--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -110,26 +110,48 @@ abstract class AbstractUri implements UriInterface
 	/**
 	 * Returns full uri string.
 	 *
-	 * @param   array  $parts  An array specifying the parts to render.
+	 * @param   mixed  $parts  An integer, a list of strings, or an array of strings specifying the parts to render.
 	 *
 	 * @return  string  The rendered URI string.
 	 *
 	 * @since   1.0
 	 */
-	public function toString(array $parts = array('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment'))
+	public function toString($parts = self::ALL)
 	{
+		if (is_string($parts))
+		{
+			$parts = func_get_args();
+		}
+
+		if (is_array($parts))
+		{
+			$realParts = 0;
+
+			foreach ($parts as $part)
+			{
+				$const = 'static::' . strtoupper($part);
+
+				if (defined($const))
+				{
+					$realParts |= constant($const);
+				}
+			}
+
+			$parts = $realParts;
+		}
+
 		// Make sure the query is created
 		$query = $this->getQuery();
 
 		$uri = '';
-		$uri .= in_array('scheme', $parts) ? (!empty($this->scheme) ? $this->scheme . '://' : '') : '';
-		$uri .= in_array('user', $parts) ? $this->user : '';
-		$uri .= in_array('pass', $parts) ? (!empty($this->pass) ? ':' : '') . $this->pass . (!empty($this->user) ? '@' : '') : '';
-		$uri .= in_array('host', $parts) ? $this->host : '';
-		$uri .= in_array('port', $parts) ? (!empty($this->port) ? ':' : '') . $this->port : '';
-		$uri .= in_array('path', $parts) ? $this->path : '';
-		$uri .= in_array('query', $parts) ? (!empty($query) ? '?' . $query : '') : '';
-		$uri .= in_array('fragment', $parts) ? (!empty($this->fragment) ? '#' . $this->fragment : '') : '';
+		$uri .= $parts & static::SCHEME   ? (!empty($this->scheme) ? $this->scheme . '://' : '') : '';
+		$uri .= $parts & static::USER     ? $this->user : '';
+		$uri .= $parts & static::PASS     ? (!empty($this->pass) ? ':' : '') . $this->pass . (!empty($this->user) ? '@' : '') : '';
+		$uri .= $parts & static::HOST     ? $this->host : '';
+		$uri .= $parts & static::PORT     ? (!empty($this->port) ? ':' : '') . $this->port : '';
+		$uri .= $parts & static::PATH     ? $this->path : '';
+		$uri .= $parts & static::QUERY    ? (!empty($query) ? '?' . $query : '') : '';
+		$uri .= $parts & static::FRAGMENT ? (!empty($this->fragment) ? '#' . $this->fragment : '') : '';
 
 		return $uri;
 	}

--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -110,42 +110,51 @@ abstract class AbstractUri implements UriInterface
 	/**
 	 * Returns full uri string.
 	 *
-	 * @param   mixed  $parts  An integer, or an array of strings specifying the parts to render.
+	 * @param   array  $parts  An array of strings specifying the parts to render.
 	 *
 	 * @return  string  The rendered URI string.
 	 *
 	 * @since   1.0
 	 */
-	public function toString($parts = self::ALL)
+	public function toString(array $parts = array('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment'))
 	{
-		if (is_array($parts))
+		$bitmask = 0;
+
+		foreach ($parts as $part)
 		{
-			$realParts = 0;
+			$const = 'static::' . strtoupper($part);
 
-			foreach ($parts as $part)
+			if (defined($const))
 			{
-				$const = 'static::' . strtoupper($part);
-
-				if (defined($const))
-				{
-					$realParts |= constant($const);
-				}
+				$bitmask |= constant($const);
 			}
-
-			$parts = $realParts;
 		}
 
+		return $this->render($bitmask);
+	}
+
+	/**
+	 * Returns full uri string.
+	 *
+	 * @param   integer  $parts  A bitmask specifying the parts to render.
+	 *
+	 * @return  string  The rendered URI string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function render($parts = self::ALL)
+	{
 		// Make sure the query is created
 		$query = $this->getQuery();
 
 		$uri = '';
-		$uri .= $parts & static::SCHEME   ? (!empty($this->scheme) ? $this->scheme . '://' : '') : '';
-		$uri .= $parts & static::USER     ? $this->user : '';
-		$uri .= $parts & static::PASS     ? (!empty($this->pass) ? ':' : '') . $this->pass . (!empty($this->user) ? '@' : '') : '';
-		$uri .= $parts & static::HOST     ? $this->host : '';
-		$uri .= $parts & static::PORT     ? (!empty($this->port) ? ':' : '') . $this->port : '';
-		$uri .= $parts & static::PATH     ? $this->path : '';
-		$uri .= $parts & static::QUERY    ? (!empty($query) ? '?' . $query : '') : '';
+		$uri .= $parts & static::SCHEME ? (!empty($this->scheme) ? $this->scheme . '://' : '') : '';
+		$uri .= $parts & static::USER ? $this->user : '';
+		$uri .= $parts & static::PASS ? (!empty($this->pass) ? ':' : '') . $this->pass . (!empty($this->user) ? '@' : '') : '';
+		$uri .= $parts & static::HOST ? $this->host : '';
+		$uri .= $parts & static::PORT ? (!empty($this->port) ? ':' : '') . $this->port : '';
+		$uri .= $parts & static::PATH ? $this->path : '';
+		$uri .= $parts & static::QUERY ? (!empty($query) ? '?' . $query : '') : '';
 		$uri .= $parts & static::FRAGMENT ? (!empty($this->fragment) ? '#' . $this->fragment : '') : '';
 
 		return $uri;

--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -101,7 +101,7 @@ interface UriInterface
 	/**
 	 * Returns full uri string.
 	 *
-	 * @param   mixed  $parts  An integer, a list of strings, or an array of strings specifying the parts to render.
+	 * @param   mixed  $parts  An integer, or an array of strings specifying the parts to render.
 	 *
 	 * @return  string  The rendered URI string.
 	 *

--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -18,6 +18,78 @@ namespace Joomla\Uri;
 interface UriInterface
 {
 	/**
+	 * Include the scheme (http, https, etc.)
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const SCHEME = 1;
+
+	/**
+	 * Include the user
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const USER = 2;
+
+	/**
+	 * Include the password
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const PASS = 4;
+
+	/**
+	 * Include the host
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const HOST = 8;
+
+	/**
+	 * Include the port
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const PORT = 16;
+
+	/**
+	 * Include the path
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const PATH = 32;
+
+	/**
+	 * Include the query string
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const QUERY = 64;
+
+	/**
+	 * Include the fragment
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const FRAGMENT = 128;
+
+	/**
+	 * Include all available url parts (scheme, user, pass, host, port, path, query, fragment)
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const ALL = 255;
+
+	/**
 	 * Magic method to get the string representation of the URI object.
 	 *
 	 * @return  string
@@ -29,13 +101,13 @@ interface UriInterface
 	/**
 	 * Returns full uri string.
 	 *
-	 * @param   array  $parts  An array specifying the parts to render.
+	 * @param   mixed  $parts  An integer, a list of strings, or an array of strings specifying the parts to render.
 	 *
 	 * @return  string  The rendered URI string.
 	 *
 	 * @since   1.0
 	 */
-	public function toString(array $parts = array('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment'));
+	public function toString($parts = self::All);
 
 	/**
 	 * Checks if variable exists.

--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -101,13 +101,13 @@ interface UriInterface
 	/**
 	 * Returns full uri string.
 	 *
-	 * @param   mixed  $parts  An integer, or an array of strings specifying the parts to render.
+	 * @param   array  $parts  An array of strings specifying the parts to render.
 	 *
 	 * @return  string  The rendered URI string.
 	 *
 	 * @since   1.0
 	 */
-	public function toString($parts = self::All);
+	public function toString(array $parts = array('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment'));
 
 	/**
 	 * Checks if variable exists.


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
A) Stop type-hinting `UriInterface::toString` and `AbstractUri::toString` so that array isn't required
B) Check if a string has been passed, if so get the $parts array from func_get_args
C) Use class constants as flags for each url part

Basically, this makes url-part specification doable in three different ways.

```php
// Classic:
$uri->toString(array('path', 'query', 'fragment'));

// Simplified:
$uri->toString('path', 'query', 'fragment');

// Flags:
$uri->toString(UriInterface::PATH | UriInterface::QUERY | UriInterface:FRAGMENT);
// or, since you'll typically be using JUri and it inherits these constants 
$uri->toString(JUri::PATH | JUri::QUERY | JUri:FRAGMENT);
```

### Testing Instructions
Run the tests. There are tests. 

### Documentation Changes Required
Probably not.