### PR TITLE
[2.0] Improve URIHelper::parse_url

### DIFF
--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -36,12 +36,6 @@ class UriHelper
 			return parse_url($url, $component);
 		}
 
-		// If mbstring extension is loaded force mb conversion to UTF-8.
-		if (extension_loaded('mbstring') === true && function_exists('mb_convert_encoding') === true)
-		{
-			return parse_url(mb_convert_encoding($url, 'UTF-8'), $component);
-		}
-
 		// Fallback to the old slower custom method to encode utf-8 chars before parsing the url.
 
 		// Build arrays of values we need to decode before parsing

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -38,19 +38,38 @@ class UriHelper
 
 		// Fallback to the old slower custom method to encode utf-8 chars before parsing the url.
 
-		// Build arrays of values we need to decode before parsing
-		$entities     = ['%21', '%2A', '%27', '%28', '%29', '%3B', '%3A', '%40', '%26', '%3D', '%24', '%2C', '%2F', '%3F', '%23', '%5B', '%5D'];
-		$replacements = ['!', '*', '\'', '(', ')', ';', ':', '@', '&', '=', '$', ',', '/', '?', '#', '[', ']'];
+		// Build arrays of values we need to decode before parsing.
+		$entities     = [
+			'%21' => '!',
+			'%2A' => '*',
+			'%27' => '\'',
+			'%28' => '(',
+			'%29' => ')',
+			'%3B' => ';',
+			'%3A' => ':',
+			'%40' => '@',
+			'%26' => '&',
+			'%3D' => '=',
+			'%24' => '$',
+			'%2C' => ',',
+			'%2F' => '/',
+			'%3F' => '?',
+			'%23' => '#',
+			'%5B' => '[',
+			'%5D' => ']',
+		];
 
-		// Parse the encoded URL with special URL characters decoded so it can be parsed
-		$parts = parse_url(str_replace($entities, $replacements, urlencode($url)), $component);
+		// Parse the encoded url.
+		$parts = parse_url(strtr(urlencode($url), $entities), $component);
 
 		// Now, decode each value of the resulting array
 		if ($parts)
 		{
+			$entities = array_flip($entities);
+
 			foreach ($parts as &$value)
 			{
-				$value = urldecode(str_replace($replacements, $entities, $value));
+				$value = urldecode(strtr($value, $entities));
 			}
 		}
 

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -42,12 +42,8 @@ class UriHelper
 		$entities     = ['%21', '%2A', '%27', '%28', '%29', '%3B', '%3A', '%40', '%26', '%3D', '%24', '%2C', '%2F', '%3F', '%23', '%5B', '%5D'];
 		$replacements = ['!', '*', '\'', '(', ')', ';', ':', '@', '&', '=', '$', ',', '/', '?', '#', '[', ']'];
 
-		// Create encoded URL with special URL characters decoded so it can be parsed
-		// All other characters will be encoded
-		$encodedURL = str_replace($entities, $replacements, urlencode($url));
-
-		// Parse the encoded URL
-		$parts = parse_url($encodedURL, $component);
+		// Parse the encoded URL with special URL characters decoded so it can be parsed
+		$parts = parse_url(str_replace($entities, $replacements, urlencode($url)), $component);
 
 		// Now, decode each value of the resulting array
 		if ($parts)

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -32,7 +32,7 @@ class UriHelper
 	public static function parse_url($url, $component = -1)
 	{
 		// If no UTF-8 chars in the url just parse it using php native parse_url which is faster.
-		if (preg_match('#^.#u', $url) === 1)
+		if (preg_match('#^.#u', $url) === 0)
 		{
 			return parse_url($url, $component);
 		}

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -39,7 +39,7 @@ class UriHelper
 		// Fallback to the old slower custom method to encode utf-8 chars before parsing the url.
 
 		// Build arrays of values we need to decode before parsing.
-		$entities     = [
+		$entities = [
 			'%21' => '!',
 			'%2A' => '*',
 			'%27' => '\'',

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -26,6 +26,7 @@ class UriHelper
 	 * @return  mixed  Associative array or false if badly formed URL.
 	 *
 	 * @link    https://secure.php.net/manual/en/function.parse-url.php
+	 * @link    https://secure.php.net/manual/en/function.setlocale.php
 	 * @since   1.0
 	 */
 	public static function parse_url($url, $component = -1)

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -36,7 +36,7 @@ class UriHelper
 		if ($currentLocaleLcCType !== false)
 		{
 			// UTF-8 LC_CTYPE locale, just use PHP native method.
-			if (stripos($currentLocaleLcCType, 'UTF-8') !== false || stripos($currentLocaleLcCType, 'UTF8') !== false)
+			if ($currentLocaleLcCType === 'C' || stripos($currentLocaleLcCType, 'UTF-8') !== false || stripos($currentLocaleLcCType, 'UTF8') !== false)
 			{
 				return parse_url($url, $component);
 			}

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -32,7 +32,7 @@ class UriHelper
 	public static function parse_url($url, $component = -1)
 	{
 		// If no UTF-8 chars in the url just parse it using php native parse_url which is faster.
-		if (utf8_decode($url) === $url)
+		if (utf8_encode($url) === $url)
 		{
 			return parse_url($url, $component);
 		}

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -26,7 +26,6 @@ class UriHelper
 	 * @return  mixed  Associative array or false if badly formed URL.
 	 *
 	 * @link    https://secure.php.net/manual/en/function.parse-url.php
-	 * @link    https://secure.php.net/manual/en/function.setlocale.php
 	 * @since   1.0
 	 */
 	public static function parse_url($url, $component = -1)

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -42,7 +42,7 @@ class UriHelper
 
 		// If UTF-8 locale found, just use PHP native method which is faster.
 		if ($currentLocaleLcCType !== false && $currentLocaleLcCType === 'C'
-		    || stripos($currentLocaleLcCType, 'UTF-8') !== false || stripos($currentLocaleLcCType, 'UTF8') !== false)
+			|| stripos($currentLocaleLcCType, 'UTF-8') !== false || stripos($currentLocaleLcCType, 'UTF8') !== false)
 		{
 			return parse_url($url, $component);
 		}

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -36,10 +36,10 @@ class UriHelper
 			return parse_url($url, $component);
 		}
 
-		// Fallback to the old slower custom method to encode utf-8 chars before parsing the url.
+		// URL with UTF-8 chars in the url.
 
-		// Build arrays of values we need to decode before parsing.
-		$entities = [
+		// Build the reserved uri encoded characters map.
+		$reservedUriCharactersMap = [
 			'%21' => '!',
 			'%2A' => '*',
 			'%27' => '\'',
@@ -59,20 +59,10 @@ class UriHelper
 			'%5D' => ']',
 		];
 
-		// Parse the encoded url.
-		$parts = parse_url(strtr(urlencode($url), $entities), $component);
+		// Encode the URL (so UTF-8 chars are encoded), revert the encoding in the reserved uri characters and parse the url.
+		$parts = parse_url(strtr(urlencode($url), $reservedUriCharactersMap), $component);
 
-		// Now, decode each value of the resulting array
-		if ($parts)
-		{
-			$entities = array_flip($entities);
-
-			foreach ($parts as &$value)
-			{
-				$value = urldecode(strtr($value, $entities));
-			}
-		}
-
-		return $parts;
+		// With a well formed url decode the url (so UTF-8 chars are decoded).
+		return $parts ? array_map('urldecode', $parts) : $parts;
 	}
 }

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -48,7 +48,7 @@ class UriHelper
 		}
 
 		// Non UTF-8 LC_CTYPE locale, try to use 'C' locale for parsing the url.
-		if (@setlocale(LC_CTYPE, 'C') === 'C')
+		if ($currentLocaleLcCType !== false && @setlocale(LC_CTYPE, 'C') === 'C')
 		{
 			$parsedUrl = parse_url($url, $component);
 

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -37,27 +37,6 @@ class UriHelper
 			return parse_url($url, $component);
 		}
 
-		// Get the current LC_CTYPE locale.
-		$currentLocaleLcCType = @setlocale(LC_CTYPE, 0);
-
-		// If UTF-8 locale found, just use PHP native method which is faster.
-		if ($currentLocaleLcCType !== false
-			&& ($currentLocaleLcCType === 'C' || stripos($currentLocaleLcCType, 'UTF-8') !== false || stripos($currentLocaleLcCType, 'UTF8') !== false))
-		{
-			return parse_url($url, $component);
-		}
-
-		// Non UTF-8 LC_CTYPE locale, try to use 'C' locale for parsing the url.
-		if ($currentLocaleLcCType !== false && @setlocale(LC_CTYPE, 'C') === 'C')
-		{
-			$parsedUrl = parse_url($url, $component);
-
-			// Go back to previous locale.
-			@setlocale(LC_CTYPE, $currentLocaleLcCType);
-
-			return $parsedUrl;
-		}
-
 		// Fallback to the old slower custom method to encode utf-8 chars before parsing the url.
 
 		// Build arrays of values we need to decode before parsing

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -27,22 +27,54 @@ class UriHelper
 	 * @link    https://secure.php.net/manual/en/function.parse-url.php
 	 * @since   1.0
 	 */
-	public static function parse_url($url)
+	public static function parse_url($url, int $component = -1)
 	{
-		// Get the current LC_CTYPE.
-		$currentLcCType = @setlocale(LC_CTYPE, '0');
+		// Get the current LC_CTYPE locale.
+		$currentLocaleLcCType = setlocale(LC_CTYPE, 0);
 
-		// For utf-8 LC_CTYPE just use PHP native method.
-		if (stripos($currentLcCType, 'utf-8') !== false)
+		if ($currentLocaleLcCType !== false)
 		{
-			return parse_url($url);
+			// UTF-8 LC_CTYPE locale, just use PHP native method.
+			if (stripos($currentLocaleLcCType, 'UTF-8') !== false || stripos($currentLocaleLcCType, 'UTF8') !== false)
+			{
+				return parse_url($url, $component);
+			}
+
+			// Non UTF-8 LC_CTYPE locale, change to C locale before parsing.
+			if (setlocale(LC_CTYPE, 'C') === 'C')
+			{
+				$parsedUrl = parse_url($url, $component);
+				setlocale(LC_CTYPE, $currentLocaleLcCType);
+
+				return $parsedUrl;
+			}
 		}
 
-		// For non utf-8 LC_CTYPE change the LC_CTYPE locale before parsing.
-		@setlocale(LC_CTYPE, 'C');
-		$parsedUrl = parse_url($url);
-		@setlocale(LC_CTYPE, $currentLcCType);
+		// Unable to get LC_CTYPE locale, use old method.
+		$result = false;
 
-		return $parsedUrl;
+		// Build arrays of values we need to decode before parsing
+		$entities     = ['%21', '%2A', '%27', '%28', '%29', '%3B', '%3A', '%40', '%26', '%3D', '%24', '%2C', '%2F', '%3F', '%23', '%5B', '%5D'];
+		$replacements = ['!', '*', "'", "(", ")", ";", ":", "@", "&", "=", "$", ",", "/", "?", "#", "[", "]"];
+
+		// Create encoded URL with special URL characters decoded so it can be parsed
+		// All other characters will be encoded
+		$encodedURL = str_replace($entities, $replacements, urlencode($url));
+
+		// Parse the encoded URL
+		$encodedParts = parse_url($encodedURL, $component);
+
+		// Now, decode each value of the resulting array
+		if ($encodedParts)
+		{
+			$result = [];
+
+			foreach ($encodedParts as $key => $value)
+			{
+				$result[$key] = urldecode(str_replace($replacements, $entities, $value));
+			}
+		}
+
+		return $result;
 	}
 }

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -36,6 +36,12 @@ class UriHelper
 			return parse_url($url, $component);
 		}
 
+		// If mbstring extension is loaded force mb conversion to UTF-8.
+		if (extension_loaded('mbstring') === true && function_exists('mb_convert_encoding') === true)
+		{
+			return parse_url(mb_convert_encoding($url, 'UTF-8'), $component);
+		}
+
 		// Fallback to the old slower custom method to encode utf-8 chars before parsing the url.
 
 		// Build arrays of values we need to decode before parsing

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -32,7 +32,7 @@ class UriHelper
 	public static function parse_url($url, $component = -1)
 	{
 		// If no UTF-8 chars in the url just parse it using php native parse_url which is faster.
-		if (utf8_encode($url) === $url)
+		if (utf8_decode($url) === $url)
 		{
 			return parse_url($url, $component);
 		}

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -32,7 +32,7 @@ class UriHelper
 	public static function parse_url($url, $component = -1)
 	{
 		// If no UTF-8 chars in the url just parse it using php native parse_url which is faster.
-		if (preg_match('#^.#u', $url) === 0)
+		if (utf8_decode($url) === $url)
 		{
 			return parse_url($url, $component);
 		}

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -32,7 +32,7 @@ class UriHelper
 	public static function parse_url($url, $component = -1)
 	{
 		// If no UTF-8 chars in the url just parse it using php native parse_url which is faster.
-		if (utf8_decode($url) === $url)
+		if (preg_match('#^.#u', $url) === 1)
 		{
 			return parse_url($url, $component);
 		}

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -28,7 +28,7 @@ class UriHelper
 	 * @link    https://secure.php.net/manual/en/function.parse-url.php
 	 * @since   1.0
 	 */
-	public static function parse_url($url, int $component = -1)
+	public static function parse_url($url, $component = -1)
 	{
 		// Get the current LC_CTYPE locale.
 		$currentLocaleLcCType = setlocale(LC_CTYPE, 0);

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -29,30 +29,20 @@ class UriHelper
 	 */
 	public static function parse_url($url)
 	{
-		$result = false;
+		// Get the current LC_CTYPE.
+		$currentLcCType = @setlocale(LC_CTYPE, '0');
 
-		// Build arrays of values we need to decode before parsing
-		$entities     = ['%21', '%2A', '%27', '%28', '%29', '%3B', '%3A', '%40', '%26', '%3D', '%24', '%2C', '%2F', '%3F', '%23', '%5B', '%5D'];
-		$replacements = ['!', '*', "'", "(", ")", ";", ":", "@", "&", "=", "$", ",", "/", "?", "#", "[", "]"];
-
-		// Create encoded URL with special URL characters decoded so it can be parsed
-		// All other characters will be encoded
-		$encodedURL = str_replace($entities, $replacements, urlencode($url));
-
-		// Parse the encoded URL
-		$encodedParts = parse_url($encodedURL);
-
-		// Now, decode each value of the resulting array
-		if ($encodedParts)
+		// For utf-8 LC_CTYPE just use PHP native method.
+		if (stripos($currentLcCType, 'utf-8') !== false)
 		{
-			$result = [];
-
-			foreach ($encodedParts as $key => $value)
-			{
-				$result[$key] = urldecode(str_replace($replacements, $entities, $value));
-			}
+			return parse_url($url);
 		}
 
-		return $result;
+		// For non utf-8 LC_CTYPE change the LC_CTYPE locale before parsing.
+		@setlocale(LC_CTYPE, 'C');
+		$parsedUrl = parse_url($url);
+		@setlocale(LC_CTYPE, $currentLcCType);
+
+		return $parsedUrl;
 	}
 }

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -32,7 +32,7 @@ class UriHelper
 	public static function parse_url($url, $component = -1)
 	{
 		// If no UTF-8 chars in the url just parse it using php native parse_url which is faster.
-		if (utf8_encode(utf8_decode($url)) === $url)
+		if (utf8_decode($url) === $url)
 		{
 			return parse_url($url, $component);
 		}

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -41,7 +41,8 @@ class UriHelper
 		$currentLocaleLcCType = @setlocale(LC_CTYPE, 0);
 
 		// If UTF-8 locale found, just use PHP native method which is faster.
-		if ($currentLocaleLcCType !== false && $currentLocaleLcCType === 'C' || stripos($currentLocaleLcCType, 'UTF-8') !== false || stripos($currentLocaleLcCType, 'UTF8') !== false)
+		if ($currentLocaleLcCType !== false && $currentLocaleLcCType === 'C'
+		    || stripos($currentLocaleLcCType, 'UTF-8') !== false || stripos($currentLocaleLcCType, 'UTF8') !== false)
 		{
 			return parse_url($url, $component);
 		}

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -20,7 +20,8 @@ class UriHelper
 	/**
 	 * Does a UTF-8 safe version of PHP parse_url function
 	 *
-	 * @param   string  $url  URL to parse
+	 * @param   string   $url        URL to parse
+	 * @param   integer  $component  Retrieve just a specific URL component
 	 *
 	 * @return  mixed  Associative array or false if badly formed URL.
 	 *

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -41,10 +41,21 @@ class UriHelper
 		$currentLocaleLcCType = @setlocale(LC_CTYPE, 0);
 
 		// If UTF-8 locale found, just use PHP native method which is faster.
-		if ($currentLocaleLcCType !== false && ($currentLocaleLcCType === 'C'
-			|| stripos($currentLocaleLcCType, 'UTF-8') !== false || stripos($currentLocaleLcCType, 'UTF8') !== false))
+		if ($currentLocaleLcCType !== false
+			&& ($currentLocaleLcCType === 'C' || stripos($currentLocaleLcCType, 'UTF-8') !== false || stripos($currentLocaleLcCType, 'UTF8') !== false))
 		{
 			return parse_url($url, $component);
+		}
+
+		// Non UTF-8 LC_CTYPE locale, try to use 'C' locale for parsing the url.
+		if (@setlocale(LC_CTYPE, 'C') === 'C')
+		{
+			$parsedUrl = parse_url($url, $component);
+
+			// Go back to previous locale.
+			@setlocale(LC_CTYPE, $currentLocaleLcCType);
+
+			return $parsedUrl;
 		}
 
 		// Fallback to the old slower custom method to encode utf-8 chars before parsing the url.

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -41,8 +41,8 @@ class UriHelper
 		$currentLocaleLcCType = @setlocale(LC_CTYPE, 0);
 
 		// If UTF-8 locale found, just use PHP native method which is faster.
-		if ($currentLocaleLcCType !== false && $currentLocaleLcCType === 'C'
-			|| stripos($currentLocaleLcCType, 'UTF-8') !== false || stripos($currentLocaleLcCType, 'UTF8') !== false)
+		if ($currentLocaleLcCType !== false && ($currentLocaleLcCType === 'C'
+			|| stripos($currentLocaleLcCType, 'UTF-8') !== false || stripos($currentLocaleLcCType, 'UTF8') !== false))
 		{
 			return parse_url($url, $component);
 		}


### PR DESCRIPTION
Pull Request for Improvement

### Introduction

The `URIHelper::parse_url()` is used in all `JRoute::_()` calls in the cms (ex: building menus, breadcrumbs, sef, etc) so is a very used method.
Also one as to take in consideration that most cms URLs passing trough cms `JRoute::_()` are not utf-8 (ex: `index.php?Itemid=222`)
Improving it's performance will do is little part in improving performance in the CMS.

So this PR tries to improve it's performance by only using the custom parse_url function when the url has utf-8 chars.

### Summary of Changes

Improves performance of URIHelper::parse_url.
Also adds the component parameter as native parse_url.

### Testing Instructions

- Unit tests pass
- Code review
- To test use the following code in a cms 4.0 template index.php before and after the PR
```php
use \Joomla\Uri\UriHelper;

$iterationsPerUrl = 1000;
$uriToTest = [
	'index.php',
	'index.php?ItemId=122',
	'/index.php/username-reminder?view=remind',
	'https://domain.tld/',
	'https://domain.tld/en/about?a=b#anchor',
	'https://domain.tld/path/script.php?foo=%21%2A%27%28%29%3B%3A%40%26%3D%24%2C%2F%3F%23%5B%5D&bar=foo#anchor',
	'https://do身ain.tld/中文/纹身馆简介你好/媒体报道',
];


foreach ($uriToTest as $url)
{
	$start = microtime(true);
	for ($i = 1; $i <= $iterationsPerUrl; $i++)
	{
		UriHelper::parse_url($url);
	}
	echo '- [' . number_format(((microtime(true) - $start) * 1000), 3) . ' ms] Processing ' . $url . '' .PHP_EOL;
}
```

My best results on PHP 7.0.19 in Linux for this urls parsed:
- Before:
```
- [2.133 ms] Processing index.php
- [3.315 ms] Processing index.php?ItemId=122
- [3.894 ms] Processing /index.php/username-reminder?view=remind
- [4.136 ms] Processing https://domain.tld/
- [6.849 ms] Processing https://domain.tld/en/about?a=b#anchor
- [10.411 ms] Processing https://domain.tld/path/script.php?foo=%21%2A%27%28%29%3B%3A%40%26%3D%24%2C%2F%3F%23%5B%5D&bar=foo#anchor
- [11.326 ms] Processing https://do身ain.tld/中文/纹身馆简介你好/媒体报道
```
- After:
```
- [0.566 ms] Processing index.php
- [0.826 ms] Processing index.php?ItemId=122
- [0.943 ms] Processing /index.php/username-reminder?view=remind
- [0.984 ms] Processing https://domain.tld/
- [1.322 ms] Processing https://domain.tld/en/about?a=b#anchor
- [1.850 ms] Processing https://domain.tld/path/script.php?foo=%21%2A%27%28%29%3B%3A%40%26%3D%24%2C%2F%3F%23%5B%5D&bar=foo#anchor
- [4.407 ms] Processing https://do身ain.tld/中文/纹身馆简介你好/媒体报道
```
### Documentation Changes Required

None.

@frankmayer can you also review this.