### PR TITLE
Bug in AbstractUri::buildQuery - invalid HTML emitted ('[' and ']' not encoded in tagged elements list) 

### DIFF
--- a/Tests/UriTest.php
+++ b/Tests/UriTest.php
@@ -78,6 +78,33 @@ class UriTest extends TestCase
 	}
 
 	/**
+	 * Test the buildQuery method for proper encoding.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @covers  Joomla\Uri\Uri::buildQuery
+	 * @link    https://github.com/joomla-framework/uri/pull/21
+	 */
+	public function testBuildQuery()
+	{
+		$this->assertThat(
+			TestHelper::invoke(
+				$this->object,
+				'buildQuery',
+				array(
+					'option' => 'com_tags',
+					'view'   => 'tag',
+					'id'     => array(3),
+					'types'  => array(2),
+					'Itemid' => 110,
+				)
+			),
+			$this->equalTo('option=com_tags&view=tag&id[0]=3&types[0]=2&Itemid=110')
+		);
+	}
+
+	/**
 	 * Test the cleanPath method.
 	 *
 	 * @return  void

--- a/Tests/UriTest.php
+++ b/Tests/UriTest.php
@@ -86,7 +86,7 @@ class UriTest extends TestCase
 	 * @covers  Joomla\Uri\Uri::buildQuery
 	 * @link    https://github.com/joomla-framework/uri/pull/21
 	 */
-	public function testBuildQuery()
+	public function testBuildQueryEncoding()
 	{
 		$this->assertThat(
 			TestHelper::invoke(

--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -307,7 +307,7 @@ abstract class AbstractUri implements UriInterface
 	 */
 	protected static function buildQuery(array $params)
 	{
-		return urldecode(http_build_query($params, '', '&'));
+		return http_build_query($params, '', '&');
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/17365

### Summary of Changes

Remove the urldecode

### Testing Instructions

@LivioCavallo please provide some test instructions

### Documentation Changes Required

B/C break?