### PR TITLE
Rename and typesafe strpos

### DIFF
--- a/Tests/UriImmutableTest.php
+++ b/Tests/UriImmutableTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since  1.0
  */
-class UriImmuteableTest extends TestCase
+class UriImmutableTest extends TestCase
 {
 	/**
 	 * Object under test

--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -360,7 +360,7 @@ abstract class AbstractUri implements UriInterface
 		$retval = ($parts) ? true : false;
 
 		// We need to replace &amp; with & for parse_str to work right...
-		if (isset($parts['query']) && strpos($parts['query'], '&amp;'))
+		if (isset($parts['query']) && strpos($parts['query'], '&amp;') !== false)
 		{
 			$parts['query'] = str_replace('&amp;', '&', $parts['query']);
 		}


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
* Rename the UriImmuteableTest to UriImmutableTest (tea -> ta)
* if (isset($parts['query']) && strpos($parts['query'], '&amp;') !== false)  ..strpos everytime with explizit test

### Testing Instructions
nothing
### Documentation Changes Required
nothing