### PR TITLE
[Feature] RFC1738 compliant URL Parsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 phpunit.xml
 /build/
+/work/

--- a/Tests/UriHelperTest.php
+++ b/Tests/UriHelperTest.php
@@ -19,23 +19,27 @@ class UriHelperTest extends TestCase
 	/**
 	 * Test the parse_url method.
 	 *
-	 * @return  array
-	 *
 	 * @since   1.0
 	 */
-	public function testParse_Url()
+	public function testParse_Url1()
 	{
-		$url = 'http://localhost/joomla_development/j16_trunk/administrator/index.php?option=com_contact&view=contact&layout=edit&id=5';
+		$url      = 'http://localhost/joomla_development/j16_trunk/administrator/index.php?option=com_contact&view=contact&layout=edit&id=5';
 		$expected = parse_url($url);
-		$actual = UriHelper::parse_url($url);
+		$actual   = UriHelper::parse_url($url);
 		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+	}
 
+	public function testParse_Url2()
+	{
 		// Test all parts of query
 		$url = 'https://john:doe@www.google.com:80/folder/page.html#id?var=kay&var2=key&true';
 		$expected = parse_url($url);
 		$actual = UriHelper::parse_url($url);
 		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+	}
 
+	public function testParse_Url3()
+	{
 		// Test special characters in URL
 		$url = 'http://joomla.org/mytestpath/È';
 		$expected = parse_url($url);
@@ -44,19 +48,28 @@ class UriHelperTest extends TestCase
 		$expected['path'] = '/mytestpath/È';
 		$actual = UriHelper::parse_url($url);
 		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+	}
 
+	public function testParse_Url4()
+	{
 		// Test special characters in URL
 		$url = 'http://mydomain.com/!*\'();:@&=+$,/?%#[]" \\';
 		$expected = parse_url($url);
 		$actual = UriHelper::parse_url($url);
 		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+	}
 
+	public function testParse_Url5()
+	{
 		// Test url encoding in URL
 		$url = 'http://mydomain.com/%21%2A%27%28%29%3B%3A%40%26%3D%24%2C%2F%3F%25%23%5B%22%20%5C';
 		$expected = parse_url($url);
 		$actual = UriHelper::parse_url($url);
 		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+	}
 
+	public function testParse_Url6()
+	{
 		// Test a mix of the above
 		$url = 'http://john:doe@mydomain.com:80/%È21%25È3*%(';
 		$expected = parse_url($url);
@@ -65,8 +78,11 @@ class UriHelperTest extends TestCase
 		$expected['path'] = '/%È21%25È3*%(';
 		$actual = UriHelper::parse_url($url);
 		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+	}
 
-		// Test invalild URL
+	public function testParse_Url7()
+	{
+		// Test invalid URL
 		$url = 'http:///mydomain.com';
 		$expected = parse_url($url);
 		$actual = UriHelper::parse_url($url);

--- a/Tests/UriTest.php
+++ b/Tests/UriTest.php
@@ -6,8 +6,8 @@
 
 namespace Joomla\Uri\Tests;
 
-use Joomla\Uri\Uri;
 use Joomla\Test\TestHelper;
+use Joomla\Uri\Uri;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -121,7 +121,9 @@ class UriTest extends TestCase
 	 */
 	public function testConstruct()
 	{
-		$object = new Uri('http://someuser:somepass@www.example.com:80/path/file.html?var=value&amp;test=true#fragment');
+		$object = new Uri(
+			'http://someuser:somepass@www.example.com:80/path/file.html?var=value&amp;test=true#fragment'
+		);
 
 		$this->assertThat(
 			$object->getHost(),
@@ -165,7 +167,9 @@ class UriTest extends TestCase
 
 		$this->assertThat(
 			$this->object->toString(),
-			$this->equalTo('ftp://root:secret@www.example.org:8888/this/is/a/path/to/a/file?somevar=somevalue&somevar2=somevalue2#someFragment')
+			$this->equalTo(
+				'ftp://root:secret@www.example.org:8888/this/is/a/path/to/a/file?somevar=somevalue&somevar2=somevalue2#someFragment'
+			)
 		);
 	}
 
@@ -489,19 +493,35 @@ class UriTest extends TestCase
 	}
 
 	/**
+	 * @return \string[][]
+	 */
+	public function samplePaths()
+	{
+		/** path, expected */
+		return array(
+			array('/this/is/a/path/to/a/file.htm', '/this/is/a/path/to/a/file.htm'),
+			array('path/to/file.htm', 'path/to/file.htm'),
+			array('../path/to/file.htm', 'path/to/file.htm'),
+			array('/foo/bar/../boo.php', '/foo/boo.php'),
+			array('/foo/bar/../../boo.php', '/boo.php'),
+			array('/foo/bar/.././/boo.php', '/foo/boo.php'),
+		);
+	}
+
+	/**
 	 * Test the setPath method.
 	 *
 	 * @return  void
-	 *
+	 * @dataProvider samplePaths
 	 * @since   1.0
 	 */
-	public function testSetPath()
+	public function testSetPath($path, $expected)
 	{
-		$this->object->setPath('/this/is/a/path/to/a/file.htm');
+		$this->object->setPath($path);
 
 		$this->assertThat(
 			$this->object->getPath(),
-			$this->equalTo('/this/is/a/path/to/a/file.htm')
+			$this->equalTo($expected)
 		);
 	}
 

--- a/Tests/UrlParserTest.php
+++ b/Tests/UrlParserTest.php
@@ -1,0 +1,353 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Uri\Tests;
+
+use Joomla\Uri\Exception\InvalidCharacterException;
+use Joomla\Uri\Exception\InvalidUrlException;
+use Joomla\Uri\Exception\LoginNotAllowedException;
+use Joomla\Uri\Exception\MissingHostException;
+use Joomla\Uri\Exception\UnsupportedSchemeException;
+use Joomla\Uri\Url;
+use Joomla\Uri\UrlParser\HttpUrlParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the Joomla\Uri\Uri class.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class UrlParserTest extends TestCase
+{
+	public function sampleUrls()
+	{
+		// Input URL, isValid?, sanitised URL
+		return array(
+			array(
+				'http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment',
+				false,
+				'http://www.example.com:80/path/file.html?var=value#fragment'
+			),
+			array(
+				'http://www.example.com:80/administrator/',
+				true,
+				'http://www.example.com:80/administrator/'
+			),
+			array(
+				'http://someuser:somepass@www.example.com:80/path/file.html?var=value&test=true#fragment',
+				false,
+				'http://www.example.com:80/path/file.html?var=value&test=true#fragment'
+			),
+			array(
+				'http://www.example.com/path/file.html?field[price][from]=5&field[price][to]=10&field[name]=foo&v=45',
+				true,
+				'http://www.example.com/path/file.html?field[price][from]=5&field[price][to]=10&field[name]=foo&v=45'
+			),
+			array(
+				'http://ümläütdömain.de',
+				false,
+				'http://xn--mltdmain-1za6p8bd.de'
+			),
+			array(
+				'http://xn--mltdmain-1za6p8bd.de',
+				true,
+				'http://xn--mltdmain-1za6p8bd.de'
+			),
+			array(
+				'http://ümläütdömain.de/index.php/test-ärticle?query=föø&öther=bær#änchör',
+				false,
+				'http://xn--mltdmain-1za6p8bd.de/index.php/test-%C3%A4rticle?query=f%C3%B6%C3%B8&%C3%B6ther=b%C3%A6r#%C3%A4nch%C3%B6r'
+			),
+			array(
+				'http://localhost:8080',
+				true,
+				'http://localhost:8080'
+			),
+			array(
+				'http://localhost:8080/index.php/test-article',
+				true,
+				'http://localhost:8080/index.php/test-article'
+			),
+			array(
+				'http://www.example.com',
+				true,
+				'http://www.example.com'
+			),
+			array(
+				'http://127.0.0.1/index.php/test-article',
+				true,
+				'http://127.0.0.1/index.php/test-article'
+			),
+			array(
+				'http://www.sec.example.com?query=foo&other=bar#anchor',
+				true,
+				'http://www.sec.example.com?query=foo&other=bar#anchor'
+			),
+			array(
+				'http://johndoe:secret@localhost:8080/',
+				false,
+				'http://localhost:8080'
+			),
+			array(
+				'http://johndoe:secret@www.example.com/',
+				false,
+				'http://www.example.com'
+			),
+			array(
+				'http://www.example.com\localhost:8080/',
+				true,
+				'http://www.example.com/localhost:8080/'
+			),
+			array(
+				'http://www.example.com\@localhost:8080/',
+				true,
+				'http://www.example.com/@localhost:8080/'
+			),
+			array(
+				'www.example.com',
+				true,
+				'http://www.example.com'
+			),
+			array(
+				'file://vms.host.edu/disk$user/my/notes/note12345.txt',
+				true,
+				'file://vms.host.edu/disk$user/my/notes/note12345.txt'
+			),
+			array(
+				'file://johndoe:secret@vms.host.edu/disk$user/my/notes/note12345.txt',
+				true,
+				'file://johndoe:secret@vms.host.edu/disk$user/my/notes/note12345.txt'
+			),
+			array(
+				'file://johndoe:sec%3Aret%3F@vms.host.edu/disk$user/my/notes/note12345.txt',
+				true,
+				'file://johndoe:sec%3Aret%3F@vms.host.edu/disk$user/my/notes/note12345.txt'
+			),
+		);
+	}
+
+	/**
+	 * @param   string   $url
+	 * @param   boolean  $expectedValidationResult
+	 * @param   string   $sanitisedUrl
+	 *
+	 * @dataProvider sampleUrls
+	 */
+	public function testValidation($url, $expectedValidationResult, $sanitisedUrl)
+	{
+		$this->assertEquals($expectedValidationResult, Url::isValid($url));
+		$this->assertEquals($sanitisedUrl, Url::sanitise($url));
+	}
+
+	/**
+	 * An UnsupportedSchemeException is thrown, if the protocol is not supported by the parser
+	 */
+	public function testUnsupportedScheme()
+	{
+		try
+		{
+			Url::sanitise('ftp://example.com');
+			$this->fail('Expected exception not thrown');
+		}
+		catch (UnsupportedSchemeException $exception)
+		{
+			$this->addToAssertionCount(1);
+		}
+	}
+
+	/**
+	 * @testdox An InvalidCharacterException is thrown, if the URL contains invalid characters
+	 */
+	public function testInvalidCharacters()
+	{
+		try
+		{
+			$parser = new HttpUrlParser();
+			$parser->parse('This is not a URL');
+			$this->fail('Expected exception not thrown');
+		}
+		catch (InvalidCharacterException $exception)
+		{
+			$this->addToAssertionCount(1);
+		}
+
+	}
+
+	/**
+	 * @testdox An InvalidUrlException is thrown, if URL cannot be parsed
+	 */
+	public function testInvalidUrl()
+	{
+		try
+		{
+			$parser = new HttpUrlParser();
+			$parser->parse('123');
+			$this->fail('Expected exception not thrown');
+		}
+		catch (InvalidUrlException $exception)
+		{
+			$this->addToAssertionCount(1);
+		}
+
+	}
+
+	/**
+	 * @testdox A MissingHostException is thrown, if no host is specified
+	 */
+	public function testMissingHost()
+	{
+		try
+		{
+			$parser = new HttpUrlParser();
+			$parser->parse('http:///index.php');
+			$this->fail('Expected exception not thrown');
+		}
+		catch (MissingHostException $exception)
+		{
+			$this->addToAssertionCount(1);
+		}
+
+	}
+
+	/**
+	 * @testdox When fixing is allowed, host is set to localhost, if no host is specified
+	 */
+	public function testFixMissingHost()
+	{
+		$parser = new HttpUrlParser();
+		$result = $parser->parse('http:///index.php', array('fix' => true));
+
+		$this->assertEquals('localhost', $result['host']);
+	}
+
+	/**
+	 * @testdox A LoginNotAllowedException is thrown, if 'user[:pass]@' is specified
+	 */
+	public function testLogin1()
+	{
+		$url = 'http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment';
+
+		try
+		{
+			Url::build(Url::parse($url));
+			$this->fail('Expected exception not thrown');
+		} catch (LoginNotAllowedException $exception) {
+			$this->addToAssertionCount(1);
+		}
+	}
+
+	/**
+	 * @testdox User and password are removed, if option 'fix' is true
+	 */
+	public function testLogin2()
+	{
+		$url = 'http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment';
+		$expected = 'http://www.example.com:80/path/file.html?var=value#fragment';
+
+		$sanitisedUrl = Url::build(Url::parse($url, array('fix' => true)));
+		$this->assertEquals($expected, $sanitisedUrl);
+	}
+
+	/**
+	 * @testdox User and password are kept, if option 'allowLogin' is true
+	 */
+	public function testLogin3()
+	{
+		$url = 'http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment';
+
+		$sanitisedUrl = Url::build(Url::parse($url, array('allowLogin' => true)));
+		$this->assertEquals($url, $sanitisedUrl);
+	}
+
+	/**
+	 * @testdox User and password are escaped, if option 'fix' is true
+	 */
+	public function testLogin4()
+	{
+		$url = 'http://someüser:somepäss@www.example.com:80/path/file.html?var=value#fragment';
+		$expected = 'http://some%C3%BCser:somep%C3%A4ss@www.example.com/path/file.html?var=value#fragment';
+
+		$sanitisedUrl = Url::build(Url::parse($url, array('fix' => true, 'allowLogin' => true)));
+		$this->assertEquals($expected, $sanitisedUrl);
+	}
+
+	/**
+	 * @testdox Default port is added, if option 'addPort' is true
+	 */
+	public function testAddPort()
+	{
+		$url = 'http://www.example.com/path/file.html?var=value#fragment';
+		$expected = 'http://www.example.com:80/path/file.html?var=value#fragment';
+
+		$sanitisedUrl = Url::build(Url::parse($url, array('addPort' => true)));
+		$this->assertEquals($expected, $sanitisedUrl);
+
+		$url = 'https://www.example.com/path/file.html?var=value#fragment';
+		$expected = 'https://www.example.com:443/path/file.html?var=value#fragment';
+
+		$sanitisedUrl = Url::build(Url::parse($url, array('addPort' => true)));
+		$this->assertEquals($expected, $sanitisedUrl);
+	}
+
+	public function sampleParts()
+	{
+		/** parts array, expected url */
+		return array(
+			array(
+				array(
+					'scheme' => 'http',
+					'host'   => 'localhost',
+					'path'   => '/absolute/path/index.php',
+					'query'  => 'foo=1&bar=2',
+				),
+				'http://localhost/%2Fabsolute/path/index.php?foo=1&bar=2'
+			),
+			array(
+				array(
+					'host'   => 'localhost',
+					'path'   => 'path/index.php',
+				),
+				'http://localhost/path/index.php'
+			),
+			array(
+				array(
+					'scheme' => 'http',
+					'host'   => 'xn--mltdmain-1za6p8bd.de',
+					'path'   => 'path/index.php',
+				),
+				'http://xn--mltdmain-1za6p8bd.de/path/index.php'
+			),
+			array(
+				array(
+					'scheme' => 'file',
+					'user' => 'johndoe',
+					'pass' => 'secret',
+					'path'   => '/absolute/path/index.php',
+				),
+				'file://johndoe:secret@/%2Fabsolute/path/index.php'
+			),
+			array(
+				array(
+					'scheme' => 'file',
+					'user' => 'johndoe',
+					'pass' => 'secret',
+					'path'   => '%2Fabsolute/path/index.php',
+				),
+				'file://johndoe:secret@/%2Fabsolute/path/index.php'
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider sampleParts
+	 */
+	public function testBuild($parts, $expectedUrl)
+	{
+		$url = Url::build($parts);
+
+		$this->assertEquals($expectedUrl, $url);
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "homepage": "https://github.com/joomla-framework/uri",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^5.3.10|^7.0|^8.0"
+        "php": "^5.3.10|^7.0|^8.0",
+        "algo26-matthias/idna-convert": "~3.0",
+        "joomla/utilities": "^1.6"
     },
     "require-dev": {
         "joomla/coding-standards": "~2.0@alpha",

--- a/src/Exception/InvalidCharacterException.php
+++ b/src/Exception/InvalidCharacterException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Joomla\Uri\Exception;
+
+/**
+ * Class InvalidCharacterException
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class InvalidCharacterException extends UrlParserException
+{
+	public function __construct(\Exception $previous = null)
+	{
+		parent::__construct(
+			'URL contains invalid character(s)',
+			$previous
+		);
+	}
+}

--- a/src/Exception/InvalidUrlException.php
+++ b/src/Exception/InvalidUrlException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Joomla\Uri\Exception;
+
+class InvalidUrlException extends UrlParserException
+{
+	public function __construct(\Exception $previous = null)
+	{
+		parent::__construct(
+			'URL could not be parsed',
+			$previous
+		);
+	}
+}

--- a/src/Exception/LoginNotAllowedException.php
+++ b/src/Exception/LoginNotAllowedException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Joomla\Uri\Exception;
+
+class LoginNotAllowedException extends UrlParserException
+{
+	public function __construct(\Exception $previous = null)
+	{
+		parent::__construct(
+			'User name or password is not allowed',
+			$previous
+		);
+	}
+}

--- a/src/Exception/MissingHostException.php
+++ b/src/Exception/MissingHostException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Joomla\Uri\Exception;
+
+class MissingHostException extends UrlParserException
+{
+	public function __construct(\Exception $previous = null)
+	{
+		parent::__construct(
+			'URL does not specify a host',
+			$previous
+		);
+	}
+
+}

--- a/src/Exception/UnsupportedSchemeException.php
+++ b/src/Exception/UnsupportedSchemeException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Joomla\Uri\Exception;
+
+class UnsupportedSchemeException extends UrlParserException
+{
+	public function __construct($scheme, \Exception $previous = null)
+	{
+		parent::__construct(
+			"Scheme $scheme is not supported",
+			$previous
+		);
+	}
+}

--- a/src/Exception/UrlParserException.php
+++ b/src/Exception/UrlParserException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Joomla\Uri\Exception;
+
+/**
+ * Class UrlParserException
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class UrlParserException extends \InvalidArgumentException
+{
+	public function __construct($message, \Exception $previous = null)
+	{
+		parent::__construct(
+			$message,
+			0,
+			$previous
+		);
+	}
+}

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -14,6 +14,7 @@ namespace Joomla\Uri;
  * This class provides a UTF-8 safe version of parse_url().
  *
  * @since  1.0
+ * @deprecated 2.0 Use HttpUrlParser instead
  */
 class UriHelper
 {

--- a/src/Url.php
+++ b/src/Url.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Part of the Joomla Framework Uri Package
+ *
+ * @copyright  Copyright (C) 2021 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Uri;
+
+use Joomla\Uri\Exception\UnsupportedSchemeException;
+use Joomla\Uri\Exception\UrlParserException;
+
+/**
+ * Facade for different URL parsers
+ *
+ * Automatically selects the required parser depending on the scheme.
+ *
+ * @since __DEPLOY_VERSION__
+ */
+abstract class Url
+{
+	const DEFAULT_SCHEME = 'http';
+
+	/** @var string[] Supported schemes */
+	private static $classMap = array(
+		'http'   => '\\Joomla\\Uri\\UrlParser\\HttpUrlParser',
+		'https'  => '\\Joomla\\Uri\\UrlParser\\HttpUrlParser',
+		'file'   => '\\Joomla\\Uri\\UrlParser\\FileUrlParser',
+	);
+
+	/**
+	 * @param   string  $url  URL to be sanitised
+	 *
+	 * @return string  The sanitised URL
+	 */
+	public static function sanitise($url)
+	{
+		return self::build(self::parse($url, array('fix' => true)));
+	}
+
+	/**
+	 * @param   string  $url  URL to be validated
+	 *
+	 * @return  boolean  Whether the URL is valid
+	 */
+	public static function isValid($url)
+	{
+		try
+		{
+			self::parse($url, array('fix' => false));
+
+			return true;
+		}
+		catch (UrlParserException $exception)
+		{
+			return false;
+		}
+	}
+
+	/**
+	 * @param   string  $url      The URL to parse
+	 * @param   array   $options  The options
+	 *                            addPort: boolean  Always add the port if true
+	 *                            fix: boolean  Try to fix the URL
+	 *
+	 * @return  string[]
+	 */
+	public static function parse($url, $options = array())
+	{
+		return self::getParserFor($url)->parse($url, $options);
+	}
+
+	/**
+	 * @param   string[]  $parts  The URL components
+	 *
+	 * @return  string  The URL
+	 */
+	public static function build(array $parts)
+	{
+		if (!isset($parts['scheme']))
+		{
+			$parts['scheme'] = self::DEFAULT_SCHEME;
+		}
+
+		return self::getParserFor($parts['scheme'])->build($parts);
+	}
+
+	/**
+	 * @param   string  $url  URL to be parsed
+	 *
+	 * @return UrlParser
+	 */
+	private static function getParserFor($url)
+	{
+		if (preg_match('~^(\w+)(?:$|://)~', $url, $parts))
+		{
+			$scheme = strtolower($parts[1]);
+		}
+		else
+		{
+			$scheme = self::DEFAULT_SCHEME;
+		}
+
+		if (!isset(self::$classMap[$scheme]) || !class_exists(self::$classMap[$scheme]))
+		{
+			throw new UnsupportedSchemeException($scheme);
+		}
+
+		return new self::$classMap[$scheme];
+	}
+}

--- a/src/UrlParser.php
+++ b/src/UrlParser.php
@@ -1,0 +1,348 @@
+<?php
+
+namespace Joomla\Uri;
+
+use Algo26\IdnaConvert\Exception\AlreadyPunycodeException;
+use Algo26\IdnaConvert\ToIdn;
+use Algo26\IdnaConvert\ToUnicode;
+use Joomla\Uri\Exception\InvalidCharacterException;
+use Joomla\Uri\Exception\InvalidUrlException;
+use Joomla\Uri\Exception\MissingHostException;
+use Joomla\Utilities\RegEx;
+
+/**
+ * Class UrlParser
+ *
+ * @since __DEPLOY_VERSION__
+ */
+abstract class UrlParser
+{
+	const ALLOWED_CHARACTERS = 'a-z0-9\-\._\~:/\?#[\]@!\$&\'\(\)\*\+,;=';
+
+	/**
+	 * Parse the parts common to all IP URLs.
+	 *
+	 * The value returned as 'urlpath' needs further parsing according to the scheme by the child class.
+	 *
+	 * @param   string  $url      The URL to parse
+	 * @param   array   $options  The options
+	 *                            addPort: boolean  Always add the port if true
+	 *                            fix: boolean  Try to fix the URL
+	 *
+	 * @return  string[]
+	 */
+	public function parse($url, $options = array())
+	{
+		$defaultOptions = array(
+			'addPort' => false,
+			'fix'     => false,
+		);
+
+		$options = array_merge($defaultOptions, $options);
+
+		/**
+		 * Browsers convert backslashes to slashes on the fly, so it should be save to do the same here
+		 */
+		$url = str_replace('\\', '/', $url);
+
+		/**
+		 * Check for illegal characters according to RFC 3986 Section 2 (complete list of allowed characters in a URI)
+		 */
+		if ($this->hasInvalidCharacters($url))
+		{
+			if (!$options['fix'])
+			{
+				throw new InvalidCharacterException;
+			}
+
+			$url = $this->sanitise($url);
+		}
+
+		/**
+		 * RFC 1738 Section 2.1
+		 * Scheme names consist of a sequence of characters. The lower case
+		 * letters "a"--"z", digits, and the characters plus ("+"), period
+		 * ("."), and hyphen ("-") are allowed. For resiliency, programs
+		 * interpreting URLs should treat upper case letters as equivalent to
+		 * lower case in scheme names (e.g., allow "HTTP" as well as "http").
+		 */
+		$scheme = RegEx::capture("[a-zA-Z0-9+.-]+", 'scheme');
+
+		/**
+		 * The user name (and password), if present, are followed by a
+		 * commercial at-sign "@". Within the user and password field, any ":",
+		 * "@", or "/" must be encoded.
+		 */
+		$user = RegEx::capture('[^:/@]+', 'user');
+		$pass = RegEx::capture('[^:/@]+', 'pass');
+
+		/**
+		 * The fully qualified domain name of a network host, or its IP
+		 * address as a set of four decimal digit groups separated by
+		 * ".". Fully qualified domain names take the form as described
+		 * in Section 3.5 of RFC 1034 [13] and Section 2.1 of RFC 1123
+		 * [5]: a sequence of domain labels separated by ".", each domain
+		 * label starting and ending with an alphanumerical character and
+		 * possibly also containing "-" characters. The rightmost domain
+		 * label will never start with a digit, though, which
+		 * syntactically distinguishes all domain names from the IP
+		 * addresses.
+		 */
+		$ip          = RegEx::capture('\d+\.\d+\.\d+\.\d+', 'ip');
+		$domainLabel = '[a-z0-9]+' . RegEx::optional('[a-z0-9-]*[a-z0-9]');
+		$tld         = RegEx::capture('[a-z]+' . RegEx::optional('[a-z0-9-]*[a-z0-9]'), 'tld');
+		$domain      = RegEx::capture($domainLabel . '\.' . $tld, 'domain');
+		$subdomain   = RegEx::capture(RegEx::noneOrMore($domainLabel . '\.') . $domainLabel, 'subdomain');
+		$host        = RegEx::capture(
+			RegEx::optional(
+				RegEx::anyOf(
+					array(
+						$ip,
+						RegEx::optional($subdomain . '\.') . RegEx::anyOf(array("localhost", $domain))
+					)
+				)
+			),
+			'host'
+		);
+
+		/**
+		 * The port number to connect to. Most schemes designate
+		 * protocols that have a default port number. Another port number
+		 * may optionally be supplied, in decimal, separated from the
+		 * host by a colon. If the port is omitted, the colon is as well.
+		 */
+		$port = RegEx::capture('\d+', 'port');
+
+		$pattern = RegEx::optional($scheme . '://');
+		$pattern .= RegEx::optional($user . RegEx::optional(':' . $pass) . '@');
+		$pattern .= RegEx::optional($host . RegEx::optional(':' . $port));
+		$pattern .= RegEx::capture('.*', 'urlpath');
+		$pattern = "~^$pattern$~i";
+
+		$parts = RegEx::match($pattern, $url);
+
+		if (empty($parts['urlpath']))
+		{
+			$parts['urlpath'] = '';
+		}
+
+		if ($parts['urlpath'] === $url)
+		{
+			throw new InvalidUrlException;
+		}
+
+		if (empty($parts['host']) && $parts['scheme'] !== 'file')
+		{
+			if (!$options['fix'])
+			{
+				throw new MissingHostException;
+			}
+
+			$parts['host'] = 'localhost';
+		}
+
+		$this->urlDecode($parts, 'user');
+		$this->urlDecode($parts, 'pass');
+
+		$toUnicode     = new ToUnicode();
+		$parts['host'] = $toUnicode->convert($parts['host']);
+
+		if (!empty($parts['domain']))
+		{
+			$parts['domain'] = $toUnicode->convert($parts['domain']);
+		}
+
+		if (!empty($parts['subdomain']))
+		{
+			$parts['subdomain'] = $toUnicode->convert($parts['subdomain']);
+		}
+
+		return $parts;
+	}
+
+	/**
+	 * Build the part common to all IP URLs.
+	 *
+	 * Components making up the urlpath need to be added by child class.
+	 *
+	 * @param   string[]  $parts  The URL components
+	 *
+	 * @return  string  The URL
+	 */
+	public function build(array $parts)
+	{
+		$url = '';
+
+		if (isset($parts['scheme']))
+		{
+			$url .= strtolower($parts['scheme']) . '://';
+		}
+
+		if (isset($parts['user']))
+		{
+			$this->urlEncode($parts, 'user');
+			$url .= $parts['user'];
+
+			if (isset($parts['pass']))
+			{
+				$this->urlEncode($parts, 'pass');
+				$url .= ':' . $parts['pass'];
+			}
+
+			$url .= '@';
+		}
+
+		if (isset($parts['host']))
+		{
+			if ($this->hasInvalidCharacters($parts['host']))
+			{
+				$parts['host'] = $this->encodeHost($parts['host']);
+			}
+
+			$url .= $parts['host'];
+
+			if (isset($parts['port']))
+			{
+				$url .= ':' . $parts['port'];
+			}
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Try to sanitise the URL using Punycode and escaping
+	 *
+	 * @param   string  $url  The URL to be sanitised
+	 *
+	 * @return  string
+	 */
+	private function sanitise($url)
+	{
+		$parts = parse_url($url);
+
+		// Try to fix unicode domain
+		if (!empty($parts['host']))
+		{
+			$parts['host'] = $this->encodeHost($parts['host']);
+		}
+
+		// Encode forbidden characters
+		/** @noinspection RegExpDuplicateCharacterInClass */
+		$parts = preg_replace_callback(
+			'~[^' . self::ALLOWED_CHARACTERS . '%]+~ui',
+			static function ($match) {
+				return urlencode($match[0]);
+			},
+			$parts
+		);
+
+		$url = $this->buildUrl($parts);
+
+		return $url;
+	}
+
+	protected function urlEncode(array &$parts, $index)
+	{
+		if (isset($parts[$index]))
+		{
+			$parts[$index] = urlencode($parts[$index]);
+		}
+	}
+
+	protected function urlDecode(array &$parts, $index)
+	{
+		if (isset($parts[$index]) && $this->isEncoded($parts[$index]))
+		{
+			$parts[$index] = urldecode($parts[$index]);
+		}
+	}
+
+	/**
+	 * @param   string  $string
+	 *
+	 * @return bool
+	 */
+	protected function hasInvalidCharacters($string)
+	{
+		return !preg_match(
+			'~^' . RegEx::oneOrMore(RegEx::anyOf(array('[' . self::ALLOWED_CHARACTERS . ']', '%[0-9a-f]{2}'))) . '$~i',
+			$string
+		);
+	}
+
+	protected function isEncoded($string)
+	{
+		return preg_match('~%[0-9a-f]{2}~i', $string) && !$this->hasInvalidCharacters($string);
+	}
+
+	/**
+	 * Build a URL from PHP's parse_url() result
+	 *
+	 * @param   array  $parts
+	 *
+	 * @return  string;
+	 */
+	private function buildUrl(array $parts)
+	{
+		$url = empty($parts['scheme']) ? Url::DEFAULT_SCHEME : $parts['scheme'];
+		$url .= '://';
+
+		if (isset($parts['user']))
+		{
+			$url .= $parts['user'];
+
+			if (isset($parts['pass']))
+			{
+				$url .= ':' . $parts['pass'];
+			}
+
+			$url .= '@';
+		}
+
+		$url .= empty($parts['host']) ? 'localhost' : $parts['host'];
+
+		if (!empty($parts['path']))
+		{
+			$url .= $parts['path'];
+		}
+
+		if (!empty($parts['query']))
+		{
+			$url .= '?' . $parts['query'];
+		}
+
+		if (!empty($parts['fragment']))
+		{
+			$url .= '#' . $parts['fragment'];
+		}
+
+		return $url;
+	}
+
+	/**
+	 * @param $host
+	 *
+	 * @return string
+	 */
+	private function encodeHost($host)
+	{
+		try
+		{
+			$toIdn = new ToIdn;
+			$host  = $toIdn->convert($host);
+		}
+		catch (AlreadyPunycodeException $exception)
+		{
+			// Ok, do nothing
+		}
+
+		if ($host === false)
+		{
+			// Can't fix
+			throw new InvalidCharacterException;
+		}
+
+		return $host;
+	}
+}

--- a/src/UrlParser/FileUrlParser.php
+++ b/src/UrlParser/FileUrlParser.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Joomla\Uri\UrlParser;
+
+use Joomla\Uri\UrlParser;
+use Joomla\Utilities\RegEx;
+
+/**
+ * Class FileUrlParser
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class FileUrlParser extends UrlParser
+{
+	/**
+	 * A file URL takes the form:
+	 *
+	 * file://<host>/<path>
+	 *
+	 * where <host> is the fully qualified domain name of the system on
+	 * which the <path> is accessible, and <path> is a hierarchical
+	 * directory path of the form <directory>/<directory>/.../<name>.
+	 *
+	 * For example, a VMS file
+	 *
+	 * DISK$USER:[MY.NOTES]NOTE123456.TXT
+	 *
+	 * might become
+	 *
+	 * <URL:file://vms.host.edu/disk$user/my/notes/note12345.txt>
+	 *
+	 * As a special case, <host> can be the string "localhost" or the empty
+	 * string; this is interpreted as `the machine from which the URL is
+	 * being interpreted'.
+	 *
+	 * @param   string  $url      The URL to parse
+	 * @param   array   $options  The options
+	 *                            addPort: boolean  Always add the port if true
+	 *                            fix: boolean  Try to fix the URL
+	 *
+	 * @return  string[]
+	 */
+	public function parse($url, $options = array())
+	{
+		$defaultOptions = array(
+			'addPort' => false,
+			'fix'     => false,
+		);
+
+		$options = array_merge($defaultOptions, $options);
+
+		$parts = parent::parse($url, $options);
+
+		$component = '[^/]+';
+		$dir       = RegEx::oneOrMore(RegEx::optional($component) . '/');
+		$name      = RegEx::capture($component, 'name');
+		$path      = RegEx::capture(RegEx::optional($dir) . $name, 'path');
+
+		$pattern = '/' . $path;
+
+		$pattern = "~^$pattern$~";
+
+		$parts2 = RegEx::match($pattern, $parts['urlpath']);
+
+		$this->urlDecode($parts, 'path');
+		$this->urlDecode($parts, 'name');
+
+		return array_merge($parts, $parts2);
+	}
+
+	/**
+	 * @param   string[]  $parts  The URL components
+	 *
+	 * @return  string  The URL
+	 */
+	public function build(array $parts)
+	{
+		$url = parent::build($parts);
+
+		if (isset($parts['path']))
+		{
+			if ($parts['path'][0] === '/')
+			{
+				$parts['path'] = '%2F' . substr($parts['path'], 1);
+			}
+
+			if (!$this->isEncoded($parts['path']))
+			{
+				$path = explode('/', $parts['path']);
+
+				foreach ($path as $key => $value)
+				{
+					$value  = urlencode($value);
+					$oath[$key] = $value;
+				}
+
+				$parts['path'] = implode('/', $path);
+			}
+
+			$url .= '/';
+			$url .= $parts['path'];
+		}
+
+		return $url;
+	}
+}

--- a/src/UrlParser/HttpUrlParser.php
+++ b/src/UrlParser/HttpUrlParser.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Joomla\Uri\UrlParser;
+
+use Joomla\Uri\Exception\LoginNotAllowedException;
+use Joomla\Uri\UrlParser;
+use Joomla\Utilities\RegEx;
+
+/**
+ * Class HttpUrlParser
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class HttpUrlParser extends UrlParser
+{
+	/**
+	 * An HTTP URL takes the form:
+	 *
+	 * http://<host>:<port>/<path>?<searchpart>
+	 *
+	 * No user name or password is allowed.
+	 * <path> is an HTTP selector, and <searchpart> is a query
+	 * string. The <path> is optional, as is the <searchpart> and its
+	 * preceding "?". If neither <path> nor <searchpart> is present, the "/"
+	 * may also be omitted.
+	 *
+	 * Within the <path> and <searchpart> components, "/", ";", "?" are
+	 * reserved.  The "/" character may be used within HTTP to designate a
+	 * hierarchical structure.
+	 *
+	 * @param   string  $url      The URL to parse
+	 * @param   array   $options  The options
+	 *                            addPort: boolean  Always add the port if true
+	 *                            fix: boolean  Try to fix the URL
+	 *                            allowLogin: boolean  Allow user:pass@ although forbidden
+	 *
+	 * @return  string[]
+	 */
+	public function parse($url, $options = array())
+	{
+		$defaultOptions = array(
+			'addPort'    => false,
+			'fix'        => false,
+			'allowLogin' => false,
+		);
+
+		$options = array_merge($defaultOptions, $options);
+
+		$parts = parent::parse($url, $options);
+
+		if (!$options['allowLogin'] && !empty($parts['user']))
+		{
+			if (!$options['fix'])
+			{
+				throw new LoginNotAllowedException();
+			}
+
+			unset($parts['user'], $parts['pass']);
+		}
+
+		if ($options['addPort'] && empty($parts['port']))
+		{
+			$parts['port'] = $parts['scheme'] === 'https' ? 443 : 80;
+		}
+
+		$dir      = RegEx::capture('[^?#]*', 'path');
+		$query    = RegEx::capture('[^#]+', 'query');
+		$fragment = RegEx::capture('.+', 'fragment');
+
+		$pattern = RegEx::optional('/' . $dir)
+				   . RegEx::optional('\?' . $query)
+				   . RegEx::optional('#' . $fragment);
+
+		$pattern = "~^$pattern$~";
+
+		preg_match($pattern, $parts['urlpath'], $parts2);
+
+		$parts = array_filter(
+			array_merge($parts, $parts2),
+			static function ($value, $key) {
+				return !is_numeric($key) && !empty($value);
+			},
+			ARRAY_FILTER_USE_BOTH
+		);
+
+		if (isset($parts['query']))
+		{
+			$query = array();
+			parse_str($parts['query'], $query);
+			$parts['query'] = $query;
+		}
+
+		if (isset($parts['path']) && $this->isEncoded($parts['path']))
+		{
+			$parts['path'] = urldecode($parts['path']);
+		}
+
+		if (isset($parts['fragment']) && $this->isEncoded($parts['fragment']))
+		{
+			$parts['fragment'] = urldecode($parts['fragment']);
+		}
+
+		return $parts;
+	}
+
+	/**
+	 * @param   string[]  $parts  The URL components
+	 *
+	 * @return  string  The URL
+	 */
+	public function build(array $parts)
+	{
+		$url = parent::build($parts);
+
+		if (isset($parts['path']))
+		{
+			if ($parts['path'][0] === '/')
+			{
+				$parts['path'] = '%2F' . substr($parts['path'], 1);
+			}
+
+			if ($this->hasInvalidCharacters($parts['path']))
+			{
+				$path = explode('/', $parts['path']);
+
+				foreach (array_keys($path) as $key)
+				{
+					$this->urlEncode($path, $key);
+				}
+
+				$parts['path'] = implode('/', $path);
+			}
+
+			$url .= '/' . $parts['path'];
+		}
+
+		if (isset($parts['query']))
+		{
+			if (!is_array($parts['query']))
+			{
+				$query = array();
+				parse_str($parts['query'], $query);
+				$parts['query'] = $query;
+			}
+
+			$url .= '?' . str_replace(array('%5B', '%5D'), array('[', ']'), http_build_query($parts['query']));
+		}
+
+		if (isset($parts['fragment']))
+		{
+			if ($this->hasInvalidCharacters($parts['fragment']))
+			{
+				$this->urlEncode($parts, 'fragment');
+			}
+
+			$url .= '#' . $parts['fragment'];
+		}
+
+		return $url;
+	}
+}


### PR DESCRIPTION
The PHP parse_url function is very basic and does not follow RFC 1738, which defines the syntax of URLs.
The parsers implemented in this PR are modelled after the BNF in section 5 of that RFC, so they are much more precise.

### Summary of Changes

* Add URL parsers
* Add a facade for the URL parsers providing validation and sanitation.

### Testing Instructions

Replace the Uri package in an installation with this and make sure that everything works as expected.

### Documentation Changes Required

Yes, WIP