### PR TITLE
[PHP 8.1] Fix UriHelper Automatic conversion of false to array, upstream for Joomla #36774

### DIFF
--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -29,7 +29,7 @@ class UriHelper
 	 */
 	public static function parse_url($url)
 	{
-		$result = false;
+		$result = array();
 
 		// Build arrays of values we need to decode before parsing
 		$entities     = array('%21', '%2A', '%27', '%28', '%29', '%3B', '%3A', '%40', '%26', '%3D', '%24', '%2C', '%2F', '%3F', '%23', '%5B', '%5D');
@@ -51,6 +51,6 @@ class UriHelper
 			}
 		}
 
-		return $result;
+		return count($result) > 0 ? $result : false;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue joomla-cms:#36774


See original discussion in:
https://github.com/joomla/joomla-cms/pull/36774

Fixes `Deprecated: Automatic conversion of false to array is deprecated in libraries/vendor/joomla/uri/src/UriHelper.php on line 50`

Pull Request for Issue # none, directly fix proposal.

### Summary of Changes

Another PHP 8.1 warning fix.

### Testing Instructions

Just review code would be enough as it's obvious PHP 8.1 issue and fix.

Open admin aera in PHP 8.1, find this warning.

### Actual result BEFORE applying this Pull Request

`Deprecated: Automatic conversion of false to array is deprecated in libraries/vendor/joomla/uri/src/UriHelper.php on line 50`

### Expected result AFTER applying this Pull Request

Not that warning anymore.

### Documentation Changes Required

none.
