### PR TITLE
Compatibility - Provide separate testsuite for PHP 7.1+

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -18,6 +18,8 @@ local composer(phpversion, params) = {
     volumes: volumes,
     commands: [
         "php -v",
+        if phpversion == "5.4" then "composer config -g -- disable-tls false",
+        if phpversion == "5.5" then "composer config -g -- disable-tls false",
         "composer update " + params,
     ]
 };

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -18,8 +18,6 @@ local composer(phpversion, params) = {
     volumes: volumes,
     commands: [
         "php -v",
-        if phpversion == "5.4" then "composer config -g -- disable-tls true && composer config -g secure-http false && composer clearcache",
-        if phpversion == "5.5" then "composer config -g -- disable-tls true && composer config -g secure-http false && composer clearcache",
         "composer update " + params,
     ]
 };

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -18,6 +18,8 @@ local composer(phpversion, params) = {
     volumes: volumes,
     commands: [
         "php -v",
+        if phpversion == "5.4" then "composer diagnose -vvv",
+        if phpversion == "5.5" then "composer diagnose -vvv",
         "composer update " + params,
     ]
 };

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -18,8 +18,8 @@ local composer(phpversion, params) = {
     volumes: volumes,
     commands: [
         "php -v",
-        if phpversion == "5.4" then "composer config -g -- disable-tls true",
-        if phpversion == "5.5" then "composer config -g -- disable-tls true",
+        if phpversion == "5.4" then "composer config -g -- disable-tls true && composer config -g secure-http false && composer clearcache",
+        if phpversion == "5.5" then "composer config -g -- disable-tls true && composer config -g secure-http false && composer clearcache",
         "composer update " + params,
     ]
 };

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -19,15 +19,12 @@ local composer(phpversion, params) = {
     commands: [
         "php -v",
         "composer update " + params,
-        if phpversion == "8.0" then "wget https://ci.joomla.org/artifacts/phpunit8_php8_match.patch",
-        if phpversion == "8.0" then "patch -N -p0 < phpunit8_php8_match.patch"
     ]
 };
 
 local phpunit(phpversion) = {
     name: "PHPUnit",
     image: "joomlaprojects/docker-images:php" + phpversion,
-    [if phpversion == "8.0" then "failure"]: "ignore",
     commands: ["vendor/bin/phpunit"]
 };
 
@@ -135,5 +132,6 @@ local pipeline(name, phpversion, params) = {
     pipeline("7.2", "7.2", "--prefer-stable"),
     pipeline("7.3", "7.3", "--prefer-stable"),
     pipeline("7.4", "7.4", "--prefer-stable"),
-    pipeline("8.0", "8.0", "--ignore-platform-reqs --prefer-stable")
+    pipeline("8.0", "8.0", "--prefer-stable"),
+    pipeline("8.0", "8.1", "--prefer-stable")
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -124,8 +124,6 @@ local pipeline(name, phpversion, params) = {
         ]
     },
     pipeline("5.3", "5.3", "--prefer-stable"),
-    pipeline("5.4", "5.4", "--prefer-stable"),
-    pipeline("5.5", "5.5", "--prefer-stable"),
     pipeline("5.6", "5.6", "--prefer-stable"),
     pipeline("7.0", "7.0", "--prefer-stable"),
     pipeline("7.1", "7.1", "--prefer-stable"),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -133,5 +133,5 @@ local pipeline(name, phpversion, params) = {
     pipeline("7.3", "7.3", "--prefer-stable"),
     pipeline("7.4", "7.4", "--prefer-stable"),
     pipeline("8.0", "8.0", "--prefer-stable"),
-    pipeline("8.0", "8.1", "--prefer-stable")
+    pipeline("8.1", "8.1", "--prefer-stable")
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -18,8 +18,8 @@ local composer(phpversion, params) = {
     volumes: volumes,
     commands: [
         "php -v",
-        if phpversion == "5.4" then "composer config -g -- disable-tls false",
-        if phpversion == "5.5" then "composer config -g -- disable-tls false",
+        if phpversion == "5.4" then "composer config -g -- disable-tls true",
+        if phpversion == "5.5" then "composer config -g -- disable-tls true",
         "composer update " + params,
     ]
 };

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -18,8 +18,6 @@ local composer(phpversion, params) = {
     volumes: volumes,
     commands: [
         "php -v",
-        if phpversion == "5.4" then "composer diagnose -vvv",
-        if phpversion == "5.5" then "composer diagnose -vvv",
         "composer update " + params,
     ]
 };

--- a/.drone.yml
+++ b/.drone.yml
@@ -98,8 +98,6 @@ steps:
   image: joomlaprojects/docker-images:php5.3
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -128,8 +126,6 @@ steps:
   image: joomlaprojects/docker-images:php5.4
   commands:
   - php -v
-  - composer diagnose -vvv
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -158,8 +154,6 @@ steps:
   image: joomlaprojects/docker-images:php5.5
   commands:
   - php -v
-  - ""
-  - composer diagnose -vvv
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -188,8 +182,6 @@ steps:
   image: joomlaprojects/docker-images:php5.6
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -218,8 +210,6 @@ steps:
   image: joomlaprojects/docker-images:php7.0
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -248,8 +238,6 @@ steps:
   image: joomlaprojects/docker-images:php7.1
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -278,8 +266,6 @@ steps:
   image: joomlaprojects/docker-images:php7.2
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -308,8 +294,6 @@ steps:
   image: joomlaprojects/docker-images:php7.3
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -338,8 +322,6 @@ steps:
   image: joomlaprojects/docker-images:php7.4
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -368,8 +350,6 @@ steps:
   image: joomlaprojects/docker-images:php8.0
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -398,8 +378,6 @@ steps:
   image: joomlaprojects/docker-images:php8.1
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -417,6 +395,6 @@ volumes:
 
 ---
 kind: signature
-hmac: d45c8e720674d801d77affe32c4835f42a61528168001563f8b996c884b4d227
+hmac: 66c41d484a40edb043809386eac880b520262ebbdfe9395d0a812d5aaabbe50f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -99,8 +99,6 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
-  - ""
-  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -129,8 +127,6 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
-  - ""
-  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -159,8 +155,6 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
-  - ""
-  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -189,8 +183,6 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
-  - ""
-  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -219,8 +211,6 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
-  - ""
-  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -249,8 +239,6 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
-  - ""
-  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -279,8 +267,6 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
-  - ""
-  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -309,8 +295,6 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
-  - ""
-  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -339,8 +323,6 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
-  - ""
-  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -368,9 +350,7 @@ steps:
   image: joomlaprojects/docker-images:php8.0
   commands:
   - php -v
-  - composer update --ignore-platform-reqs --prefer-stable
-  - wget https://ci.joomla.org/artifacts/phpunit8_php8_match.patch
-  - patch -N -p0 < phpunit8_php8_match.patch
+  - composer update --prefer-stable
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -379,7 +359,34 @@ steps:
   image: joomlaprojects/docker-images:php8.0
   commands:
   - vendor/bin/phpunit
-  failure: ignore
+
+volumes:
+- name: composer-cache
+  host:
+    path: /tmp/composer-cache
+
+---
+kind: pipeline
+name: PHP 8.0
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: composer
+  image: joomlaprojects/docker-images:php8.1
+  commands:
+  - php -v
+  - composer update --prefer-stable
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+
+- name: PHPUnit
+  image: joomlaprojects/docker-images:php8.1
+  commands:
+  - vendor/bin/phpunit
 
 volumes:
 - name: composer-cache
@@ -388,6 +395,6 @@ volumes:
 
 ---
 kind: signature
-hmac: d21b6b782f740c9a4fdab2c148f95508a27917023b8c7c8741719e92f362cca8
+hmac: 8078d1dbb28d9785d768428d4a7da4eb4ab57128d786ca6daba87bcbd5b00849
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -128,7 +128,7 @@ steps:
   image: joomlaprojects/docker-images:php5.4
   commands:
   - php -v
-  - composer config -g -- disable-tls false
+  - composer config -g -- disable-tls true
   - ""
   - composer update --prefer-stable
   volumes:
@@ -159,7 +159,7 @@ steps:
   commands:
   - php -v
   - ""
-  - composer config -g -- disable-tls false
+  - composer config -g -- disable-tls true
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -417,6 +417,6 @@ volumes:
 
 ---
 kind: signature
-hmac: d9d72c95b7ac1e280801a18c24a984c8b359c5f6bf6bdad958af2a5b2f6df0fc
+hmac: f318bac5476dbcdac7f08569a4574f9e1a1b4f49483e1c2ec78070a0cb8299bf
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -115,62 +115,6 @@ volumes:
 
 ---
 kind: pipeline
-name: PHP 5.4
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: composer
-  image: joomlaprojects/docker-images:php5.4
-  commands:
-  - php -v
-  - composer update --prefer-stable
-  volumes:
-  - name: composer-cache
-    path: /tmp/composer-cache
-
-- name: PHPUnit
-  image: joomlaprojects/docker-images:php5.4
-  commands:
-  - vendor/bin/phpunit
-
-volumes:
-- name: composer-cache
-  host:
-    path: /tmp/composer-cache
-
----
-kind: pipeline
-name: PHP 5.5
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: composer
-  image: joomlaprojects/docker-images:php5.5
-  commands:
-  - php -v
-  - composer update --prefer-stable
-  volumes:
-  - name: composer-cache
-    path: /tmp/composer-cache
-
-- name: PHPUnit
-  image: joomlaprojects/docker-images:php5.5
-  commands:
-  - vendor/bin/phpunit
-
-volumes:
-- name: composer-cache
-  host:
-    path: /tmp/composer-cache
-
----
-kind: pipeline
 name: PHP 5.6
 
 platform:
@@ -395,6 +339,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 66c41d484a40edb043809386eac880b520262ebbdfe9395d0a812d5aaabbe50f
+hmac: a001e7574875aa67206e82d45858a1f9aaca2ebbd32328123000bd06c1b0ec2d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -98,6 +98,8 @@ steps:
   image: joomlaprojects/docker-images:php5.3
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -126,6 +128,8 @@ steps:
   image: joomlaprojects/docker-images:php5.4
   commands:
   - php -v
+  - composer diagnose -vvv
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -154,6 +158,8 @@ steps:
   image: joomlaprojects/docker-images:php5.5
   commands:
   - php -v
+  - ""
+  - composer diagnose -vvv
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -182,6 +188,8 @@ steps:
   image: joomlaprojects/docker-images:php5.6
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -210,6 +218,8 @@ steps:
   image: joomlaprojects/docker-images:php7.0
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -238,6 +248,8 @@ steps:
   image: joomlaprojects/docker-images:php7.1
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -266,6 +278,8 @@ steps:
   image: joomlaprojects/docker-images:php7.2
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -294,6 +308,8 @@ steps:
   image: joomlaprojects/docker-images:php7.3
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -322,6 +338,8 @@ steps:
   image: joomlaprojects/docker-images:php7.4
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -350,6 +368,8 @@ steps:
   image: joomlaprojects/docker-images:php8.0
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -378,6 +398,8 @@ steps:
   image: joomlaprojects/docker-images:php8.1
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -395,6 +417,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 66c41d484a40edb043809386eac880b520262ebbdfe9395d0a812d5aaabbe50f
+hmac: d45c8e720674d801d77affe32c4835f42a61528168001563f8b996c884b4d227
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -98,8 +98,6 @@ steps:
   image: joomlaprojects/docker-images:php5.3
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -128,8 +126,6 @@ steps:
   image: joomlaprojects/docker-images:php5.4
   commands:
   - php -v
-  - composer config -g -- disable-tls true && composer config -g secure-http false && composer clearcache
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -158,8 +154,6 @@ steps:
   image: joomlaprojects/docker-images:php5.5
   commands:
   - php -v
-  - ""
-  - composer config -g -- disable-tls true && composer config -g secure-http false && composer clearcache
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -188,8 +182,6 @@ steps:
   image: joomlaprojects/docker-images:php5.6
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -218,8 +210,6 @@ steps:
   image: joomlaprojects/docker-images:php7.0
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -248,8 +238,6 @@ steps:
   image: joomlaprojects/docker-images:php7.1
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -278,8 +266,6 @@ steps:
   image: joomlaprojects/docker-images:php7.2
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -308,8 +294,6 @@ steps:
   image: joomlaprojects/docker-images:php7.3
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -338,8 +322,6 @@ steps:
   image: joomlaprojects/docker-images:php7.4
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -368,8 +350,6 @@ steps:
   image: joomlaprojects/docker-images:php8.0
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -398,8 +378,6 @@ steps:
   image: joomlaprojects/docker-images:php8.1
   commands:
   - php -v
-  - ""
-  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -417,6 +395,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 84379d4fdd8610be4f2508a130156b14459e603bbdc9363058e8e45e7226d960
+hmac: 66c41d484a40edb043809386eac880b520262ebbdfe9395d0a812d5aaabbe50f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -367,7 +367,7 @@ volumes:
 
 ---
 kind: pipeline
-name: PHP 8.0
+name: PHP 8.1
 
 platform:
   os: linux
@@ -395,6 +395,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 8078d1dbb28d9785d768428d4a7da4eb4ab57128d786ca6daba87bcbd5b00849
+hmac: 66c41d484a40edb043809386eac880b520262ebbdfe9395d0a812d5aaabbe50f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -128,7 +128,7 @@ steps:
   image: joomlaprojects/docker-images:php5.4
   commands:
   - php -v
-  - composer config -g -- disable-tls true
+  - composer config -g -- disable-tls true && composer config -g secure-http false && composer clearcache
   - ""
   - composer update --prefer-stable
   volumes:
@@ -159,7 +159,7 @@ steps:
   commands:
   - php -v
   - ""
-  - composer config -g -- disable-tls true
+  - composer config -g -- disable-tls true && composer config -g secure-http false && composer clearcache
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -417,6 +417,6 @@ volumes:
 
 ---
 kind: signature
-hmac: f318bac5476dbcdac7f08569a4574f9e1a1b4f49483e1c2ec78070a0cb8299bf
+hmac: 84379d4fdd8610be4f2508a130156b14459e603bbdc9363058e8e45e7226d960
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -98,6 +98,8 @@ steps:
   image: joomlaprojects/docker-images:php5.3
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -126,6 +128,8 @@ steps:
   image: joomlaprojects/docker-images:php5.4
   commands:
   - php -v
+  - composer config -g -- disable-tls false
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -154,6 +158,8 @@ steps:
   image: joomlaprojects/docker-images:php5.5
   commands:
   - php -v
+  - ""
+  - composer config -g -- disable-tls false
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -182,6 +188,8 @@ steps:
   image: joomlaprojects/docker-images:php5.6
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -210,6 +218,8 @@ steps:
   image: joomlaprojects/docker-images:php7.0
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -238,6 +248,8 @@ steps:
   image: joomlaprojects/docker-images:php7.1
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -266,6 +278,8 @@ steps:
   image: joomlaprojects/docker-images:php7.2
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -294,6 +308,8 @@ steps:
   image: joomlaprojects/docker-images:php7.3
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -322,6 +338,8 @@ steps:
   image: joomlaprojects/docker-images:php7.4
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -350,6 +368,8 @@ steps:
   image: joomlaprojects/docker-images:php8.0
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -378,6 +398,8 @@ steps:
   image: joomlaprojects/docker-images:php8.1
   commands:
   - php -v
+  - ""
+  - ""
   - composer update --prefer-stable
   volumes:
   - name: composer-cache
@@ -395,6 +417,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 66c41d484a40edb043809386eac880b520262ebbdfe9395d0a812d5aaabbe50f
+hmac: d9d72c95b7ac1e280801a18c24a984c8b359c5f6bf6bdad958af2a5b2f6df0fc
 
 ...

--- a/Tests/php53/UriHelperTest.php
+++ b/Tests/php53/UriHelperTest.php
@@ -4,7 +4,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-namespace Joomla\Uri\Tests;
+namespace Joomla\Uri\Tests\php53;
 
 use Joomla\Uri\UriHelper;
 use PHPUnit\Framework\TestCase;

--- a/Tests/php53/UriImmutableTest.php
+++ b/Tests/php53/UriImmutableTest.php
@@ -1,0 +1,356 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Uri\Tests\php53;
+
+use Joomla\Uri\UriImmutable;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the Joomla\Uri\UriImmutable class.
+ *
+ * @since  1.0
+ */
+class UriImmutableTest extends TestCase
+{
+	/**
+	 * Object under test
+	 *
+	 * @var    UriImmutable
+	 * @since  1.0
+	 */
+	protected $object;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	protected function setUp()
+	{
+		$this->object = new UriImmutable('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment');
+	}
+
+	/**
+	 * Tests the __set method. Immutable objects will throw
+	 * an exception when you try to change a property.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.2.0
+	 * @expectedException \BadMethodCallException
+	 */
+	public function test__set()
+	{
+		$this->object->uri = 'http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment';
+	}
+
+	/**
+	 * Test the __toString method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function test__toString()
+	{
+		$this->assertThat(
+			$this->object->__toString(),
+			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+	}
+
+	/**
+	 * Test the toString method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testToString()
+	{
+		$classname = \get_class($this->object);
+
+		// The next 2 tested functions should generate equivalent results
+		$this->assertThat(
+			$this->object->toString(),
+			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->toString(array('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment')),
+			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->toString(array('scheme')),
+			$this->equalTo('http://')
+		);
+
+		$this->assertThat(
+			$this->object->toString(array('host', 'port')),
+			$this->equalTo('www.example.com:80')
+		);
+
+		$this->assertThat(
+			$this->object->toString(array('path', 'query', 'fragment')),
+			$this->equalTo('/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->toString(array('user', 'pass', 'host', 'port', 'path', 'query', 'fragment')),
+			$this->equalTo('someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+	}
+
+	/**
+	 * Test the render method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.2.0
+	 */
+	public function testRender()
+	{
+		$classname = \get_class($this->object);
+
+		$this->assertThat(
+			$this->object->render($classname::ALL),
+			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->render($classname::SCHEME),
+			$this->equalTo('http://')
+		);
+
+		$this->assertThat(
+			$this->object->render($classname::HOST | $classname::PORT),
+			$this->equalTo('www.example.com:80')
+		);
+
+		$this->assertThat(
+			$this->object->render($classname::PATH | $classname::QUERY | $classname::FRAGMENT),
+			$this->equalTo('/path/file.html?var=value#fragment')
+		);
+
+		$this->assertThat(
+			$this->object->render($classname::ALL & ~$classname::SCHEME),
+			$this->equalTo('someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+	}
+
+	/**
+	 * Test the hasVar method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testHasVar()
+	{
+		$this->assertThat(
+			$this->object->hasVar('somevar'),
+			$this->equalTo(false)
+		);
+
+		$this->assertThat(
+			$this->object->hasVar('var'),
+			$this->equalTo(true)
+		);
+	}
+
+	/**
+	 * Test the getVar method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetVar()
+	{
+		$this->assertThat(
+			$this->object->getVar('var'),
+			$this->equalTo('value')
+		);
+
+		$this->assertThat(
+			$this->object->getVar('var2'),
+			$this->equalTo('')
+		);
+
+		$this->assertThat(
+			$this->object->getVar('var2', 'default'),
+			$this->equalTo('default')
+		);
+	}
+
+	/**
+	 * Test the getQuery method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetQuery()
+	{
+		$this->assertThat(
+			$this->object->getQuery(),
+			$this->equalTo('var=value')
+		);
+
+		$this->assertThat(
+			$this->object->getQuery(true),
+			$this->equalTo(array('var' => 'value'))
+		);
+	}
+
+	/**
+	 * Test the getScheme method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetScheme()
+	{
+		$this->assertThat(
+			$this->object->getScheme(),
+			$this->equalTo('http')
+		);
+	}
+
+	/**
+	 * Test the getUser method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetUser()
+	{
+		$this->assertThat(
+			$this->object->getUser(),
+			$this->equalTo('someuser')
+		);
+	}
+
+	/**
+	 * Test the getPass method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetPass()
+	{
+		$this->assertThat(
+			$this->object->getPass(),
+			$this->equalTo('somepass')
+		);
+	}
+
+	/**
+	 * Test the getHost method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetHost()
+	{
+		$this->assertThat(
+			$this->object->getHost(),
+			$this->equalTo('www.example.com')
+		);
+	}
+
+	/**
+	 * Test the getPort method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetPort()
+	{
+		$this->assertThat(
+			$this->object->getPort(),
+			$this->equalTo('80')
+		);
+	}
+
+	/**
+	 * Test the getPath method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetPath()
+	{
+		$this->assertThat(
+			$this->object->getPath(),
+			$this->equalTo('/path/file.html')
+		);
+	}
+
+	/**
+	 * Test the getFragment method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetFragment()
+	{
+		$this->assertThat(
+			$this->object->getFragment(),
+			$this->equalTo('fragment')
+		);
+	}
+
+	/**
+	 * Test the isSsl method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testisSsl()
+	{
+		$this->object = new UriImmutable('https://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment');
+
+		$this->assertThat(
+			$this->object->isSsl(),
+			$this->equalTo(true)
+		);
+
+		$this->object = new UriImmutable('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment');
+
+		$this->assertThat(
+			$this->object->isSsl(),
+			$this->equalTo(false)
+		);
+	}
+
+    /**
+     * @testdox Calling the constructor of an instantiated UriImmutable object throws an exception.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+	public function testReconstruction()
+	{
+		$uri = new UriImmutable();
+
+		$this->expectException('BadMethodCallException');
+
+		$uri->__construct();
+	}
+}

--- a/Tests/php53/UriImmutableTest.php
+++ b/Tests/php53/UriImmutableTest.php
@@ -343,13 +343,11 @@ class UriImmutableTest extends TestCase
     /**
      * @testdox Calling the constructor of an instantiated UriImmutable object throws an exception.
      *
-     * @since __DEPLOY_VERSION__
+     * @expectedException \BadMethodCallException
      */
 	public function testReconstruction()
 	{
 		$uri = new UriImmutable();
-
-		$this->expectException('BadMethodCallException');
 
 		$uri->__construct();
 	}

--- a/Tests/php53/UriTest.php
+++ b/Tests/php53/UriTest.php
@@ -4,7 +4,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-namespace Joomla\Uri\Tests;
+namespace Joomla\Uri\Tests\php53;
 
 use Joomla\Uri\Uri;
 use Joomla\Test\TestHelper;

--- a/Tests/php71/UriHelperTest.php
+++ b/Tests/php71/UriHelperTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Uri\Tests\php71;
+
+use Joomla\Uri\UriHelper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the Joomla\Uri\UriHelper class.
+ *
+ * @since  1.0
+ */
+class UriHelperTest extends TestCase
+{
+	/**
+	 * Test the parse_url method.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function testParse_Url()
+	{
+		$url = 'http://localhost/joomla_development/j16_trunk/administrator/index.php?option=com_contact&view=contact&layout=edit&id=5';
+		$expected = parse_url($url);
+		$actual = UriHelper::parse_url($url);
+		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+
+		// Test all parts of query
+		$url = 'https://john:doe@www.google.com:80/folder/page.html#id?var=kay&var2=key&true';
+		$expected = parse_url($url);
+		$actual = UriHelper::parse_url($url);
+		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+
+		// Test special characters in URL
+		$url = 'http://joomla.org/mytestpath/È';
+		$expected = parse_url($url);
+
+		// Fix up path for UTF-8 characters
+		$expected['path'] = '/mytestpath/È';
+		$actual = UriHelper::parse_url($url);
+		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+
+		// Test special characters in URL
+		$url = 'http://mydomain.com/!*\'();:@&=+$,/?%#[]" \\';
+		$expected = parse_url($url);
+		$actual = UriHelper::parse_url($url);
+		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+
+		// Test url encoding in URL
+		$url = 'http://mydomain.com/%21%2A%27%28%29%3B%3A%40%26%3D%24%2C%2F%3F%25%23%5B%22%20%5C';
+		$expected = parse_url($url);
+		$actual = UriHelper::parse_url($url);
+		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+
+		// Test a mix of the above
+		$url = 'http://john:doe@mydomain.com:80/%È21%25È3*%(';
+		$expected = parse_url($url);
+
+		// Fix up path for UTF-8 characters
+		$expected['path'] = '/%È21%25È3*%(';
+		$actual = UriHelper::parse_url($url);
+		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+
+		// Test invalild URL
+		$url = 'http:///mydomain.com';
+		$expected = parse_url($url);
+		$actual = UriHelper::parse_url($url);
+		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+	}
+}

--- a/Tests/php71/UriImmutableTest.php
+++ b/Tests/php71/UriImmutableTest.php
@@ -4,7 +4,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-namespace Joomla\Uri\Tests;
+namespace Joomla\Uri\Tests\php71;
 
 use Joomla\Uri\UriImmutable;
 use PHPUnit\Framework\TestCase;
@@ -32,7 +32,7 @@ class UriImmutableTest extends TestCase
 	 *
 	 * @since   1.0
 	 */
-	protected function setUp()
+	protected function setUp(): void
 	{
 		$this->object = new UriImmutable('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment');
 	}
@@ -44,11 +44,12 @@ class UriImmutableTest extends TestCase
 	 * @return  void
 	 *
 	 * @since   1.2.0
-	 * @expectedException \BadMethodCallException
-	 */
+	 *
+     */
 	public function test__set()
 	{
-		$this->object->uri = 'http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment';
+        $this->expectException(\BadMethodCallException::class);
+        $this->object->uri = 'http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment';
 	}
 
 	/**
@@ -349,7 +350,7 @@ class UriImmutableTest extends TestCase
 	{
 		$uri = new UriImmutable();
 
-		$this->expectException('BadMethodCallException');
+		$this->expectException(\BadMethodCallException::class);
 
 		$uri->__construct();
 	}

--- a/Tests/php71/UriImmutableTest.php
+++ b/Tests/php71/UriImmutableTest.php
@@ -343,8 +343,6 @@ class UriImmutableTest extends TestCase
 
     /**
      * @testdox Calling the constructor of an instantiated UriImmutable object throws an exception.
-     *
-     * @since __DEPLOY_VERSION__
      */
 	public function testReconstruction()
 	{

--- a/Tests/php71/UriTest.php
+++ b/Tests/php71/UriTest.php
@@ -1,0 +1,563 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Uri\Tests\php71;
+
+use Joomla\Uri\Uri;
+use Joomla\Test\TestHelper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the Joomla\Uri\Uri class.
+ *
+ * @since  1.0
+ */
+class UriTest extends TestCase
+{
+	/**
+	 * Object under test
+	 *
+	 * @var    Uri
+	 * @since  1.0
+	 */
+	protected $object;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	protected function setUp(): void
+	{
+		$this->object = new Uri('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment');
+	}
+
+	/**
+	 * Test the __toString method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function test__toString()
+	{
+		$this->assertThat(
+			$this->object->__toString(),
+			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+	}
+
+	/**
+	 * Test the buildQuery method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.2.0
+	 */
+	public function testBuildQuery()
+	{
+		$this->assertThat(
+			TestHelper::invoke(
+				$this->object,
+				'buildQuery',
+				array(
+					'var' => 'value',
+					'foo' => 'bar'
+				)
+			),
+			$this->equalTo('var=value&foo=bar')
+		);
+	}
+
+	/**
+	 * Test the cleanPath method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.2.0
+	 */
+	public function testcleanPath()
+	{
+		$this->assertThat(
+			TestHelper::invoke(
+				$this->object,
+				'cleanPath',
+				'/foo/bar/../boo.php'
+			),
+			$this->equalTo('/foo/boo.php')
+		);
+
+		$this->assertThat(
+			TestHelper::invoke(
+				$this->object,
+				'cleanPath',
+				'/foo/bar/../../boo.php'
+			),
+			$this->equalTo('/boo.php')
+		);
+
+		$this->assertThat(
+			TestHelper::invoke(
+				$this->object,
+				'cleanPath',
+				'/foo/bar/.././/boo.php'
+			),
+			$this->equalTo('/foo/boo.php')
+		);
+	}
+
+	/**
+	 * Test the parse method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testConstruct()
+	{
+		$object = new Uri('http://someuser:somepass@www.example.com:80/path/file.html?var=value&amp;test=true#fragment');
+
+		$this->assertThat(
+			$object->getHost(),
+			$this->equalTo('www.example.com')
+		);
+
+		$this->assertThat(
+			$object->getPath(),
+			$this->equalTo('/path/file.html')
+		);
+
+		$this->assertThat(
+			$object->getScheme(),
+			$this->equalTo('http')
+		);
+	}
+
+	/**
+	 * Test the toString method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testToString()
+	{
+		$this->assertThat(
+			$this->object->toString(),
+			$this->equalTo('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment')
+		);
+
+		$this->object->setQuery('somevar=somevalue');
+		$this->object->setVar('somevar2', 'somevalue2');
+		$this->object->setScheme('ftp');
+		$this->object->setUser('root');
+		$this->object->setPass('secret');
+		$this->object->setHost('www.example.org');
+		$this->object->setPort('8888');
+		$this->object->setFragment('someFragment');
+		$this->object->setPath('/this/is/a/path/to/a/file');
+
+		$this->assertThat(
+			$this->object->toString(),
+			$this->equalTo('ftp://root:secret@www.example.org:8888/this/is/a/path/to/a/file?somevar=somevalue&somevar2=somevalue2#someFragment')
+		);
+	}
+
+	/**
+	 * Test the setVar method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSetVar()
+	{
+		$this->object->setVar('somevariable', 'somevalue');
+
+		$this->assertThat(
+			$this->object->getVar('somevariable'),
+			$this->equalTo('somevalue')
+		);
+	}
+
+	/**
+	 * Test the hasVar method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testHasVar()
+	{
+		$this->assertThat(
+			$this->object->hasVar('somevariable'),
+			$this->equalTo(false)
+		);
+
+		$this->assertThat(
+			$this->object->hasVar('var'),
+			$this->equalTo(true)
+		);
+	}
+
+	/**
+	 * Test the getVar method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetVar()
+	{
+		$this->assertThat(
+			$this->object->getVar('var'),
+			$this->equalTo('value')
+		);
+
+		$this->assertThat(
+			$this->object->getVar('var2'),
+			$this->equalTo('')
+		);
+
+		$this->assertThat(
+			$this->object->getVar('var2', 'default'),
+			$this->equalTo('default')
+		);
+	}
+
+	/**
+	 * Test the delVar method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testDelVar()
+	{
+		$this->assertThat(
+			$this->object->getVar('var'),
+			$this->equalTo('value')
+		);
+
+		$this->object->delVar('var');
+
+		$this->assertThat(
+			$this->object->getVar('var'),
+			$this->equalTo('')
+		);
+	}
+
+	/**
+	 * Test the setQuery method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSetQuery()
+	{
+		$this->object->setQuery('somevar=somevalue');
+
+		$this->assertThat(
+			$this->object->getQuery(),
+			$this->equalTo('somevar=somevalue')
+		);
+
+		$this->object->setQuery('somevar=somevalue&amp;test=true');
+
+		$this->assertThat(
+			$this->object->getQuery(),
+			$this->equalTo('somevar=somevalue&test=true')
+		);
+
+		$this->object->setQuery(array('somevar' => 'somevalue', 'test' => 'true'));
+
+		$this->assertThat(
+			$this->object->getQuery(),
+			$this->equalTo('somevar=somevalue&test=true')
+		);
+	}
+
+	/**
+	 * Test the getQuery method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetQuery()
+	{
+		$this->assertThat(
+			$this->object->getQuery(),
+			$this->equalTo('var=value')
+		);
+
+		$this->assertThat(
+			$this->object->getQuery(true),
+			$this->equalTo(array('var' => 'value'))
+		);
+
+		// Set a new query
+		$this->object->setQuery('somevar=somevalue');
+
+		// Test if query is null, to build query in getQuery call.
+		$this->assertThat(
+			$this->object->getQuery(),
+			$this->equalTo('somevar=somevalue')
+		);
+	}
+
+	/**
+	 * Test the getScheme method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetScheme()
+	{
+		$this->assertThat(
+			$this->object->getScheme(),
+			$this->equalTo('http')
+		);
+	}
+
+	/**
+	 * Test the setScheme method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSetScheme()
+	{
+		$this->object->setScheme('ftp');
+
+		$this->assertThat(
+			$this->object->getScheme(),
+			$this->equalTo('ftp')
+		);
+	}
+
+	/**
+	 * Test the getUser method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetUser()
+	{
+		$this->assertThat(
+			$this->object->getUser(),
+			$this->equalTo('someuser')
+		);
+	}
+
+	/**
+	 * Test the setUser method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSetUser()
+	{
+		$this->object->setUser('root');
+
+		$this->assertThat(
+			$this->object->getUser(),
+			$this->equalTo('root')
+		);
+	}
+
+	/**
+	 * Test the getPass method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetPass()
+	{
+		$this->assertThat(
+			$this->object->getPass(),
+			$this->equalTo('somepass')
+		);
+	}
+
+	/**
+	 * Test the setPass method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSetPass()
+	{
+		$this->object->setPass('secret');
+
+		$this->assertThat(
+			$this->object->getPass(),
+			$this->equalTo('secret')
+		);
+	}
+
+	/**
+	 * Test the getHost method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetHost()
+	{
+		$this->assertThat(
+			$this->object->getHost(),
+			$this->equalTo('www.example.com')
+		);
+	}
+
+	/**
+	 * Test the setHost method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSetHost()
+	{
+		$this->object->setHost('www.example.org');
+
+		$this->assertThat(
+			$this->object->getHost(),
+			$this->equalTo('www.example.org')
+		);
+	}
+
+	/**
+	 * Test the getPort method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetPort()
+	{
+		$this->assertThat(
+			$this->object->getPort(),
+			$this->equalTo('80')
+		);
+	}
+
+	/**
+	 * Test the setPort method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSetPort()
+	{
+		$this->object->setPort('8888');
+
+		$this->assertThat(
+			$this->object->getPort(),
+			$this->equalTo('8888')
+		);
+	}
+
+	/**
+	 * Test the getPath method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetPath()
+	{
+		$this->assertThat(
+			$this->object->getPath(),
+			$this->equalTo('/path/file.html')
+		);
+	}
+
+	/**
+	 * Test the setPath method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSetPath()
+	{
+		$this->object->setPath('/this/is/a/path/to/a/file.htm');
+
+		$this->assertThat(
+			$this->object->getPath(),
+			$this->equalTo('/this/is/a/path/to/a/file.htm')
+		);
+	}
+
+	/**
+	 * Test the getFragment method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetFragment()
+	{
+		$this->assertThat(
+			$this->object->getFragment(),
+			$this->equalTo('fragment')
+		);
+	}
+
+	/**
+	 * Test the setFragment method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSetFragment()
+	{
+		$this->object->setFragment('someFragment');
+
+		$this->assertThat(
+			$this->object->getFragment(),
+			$this->equalTo('someFragment')
+		);
+	}
+
+	/**
+	 * Test the isSsl method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testisSsl()
+	{
+		$object = new Uri('https://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment');
+
+		$this->assertThat(
+			$object->isSsl(),
+			$this->equalTo(true)
+		);
+
+		$object = new Uri('http://someuser:somepass@www.example.com:80/path/file.html?var=value#fragment');
+
+		$this->assertThat(
+			$object->isSsl(),
+			$this->equalTo(false)
+		);
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "joomla/coding-standards": "~2.0@alpha",
         "joomla/test": "~1.0",
-        "phpunit/phpunit": "^5.4.3|^6.0|^7.0|^8.0"
+        "phpunit/phpunit": "^4.8.35|^5.4.3|^6.0|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "joomla/coding-standards": "~2.0@alpha",
         "joomla/test": "~1.0",
-        "phpunit/phpunit": "^4.8.35|^5.4.3|^6.0|^7.0|^8.0"
+        "phpunit/phpunit": "^5.4.3|^6.0|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,8 @@
 <phpunit bootstrap="vendor/autoload.php" colors="false">
 	<testsuites>
 		<testsuite name="Unit">
-			<directory>Tests</directory>
+			<directory suffix="Test.php" phpVersion="7.1.0" phpVersionOperator="&lt;">Tests/php53</directory>
+			<directory suffix="Test.php" phpVersion="7.1.0" phpVersionOperator=">=">Tests/php71</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>


### PR DESCRIPTION
This allows the tests to run on PHP 8.0+.

Pull Request for Issue #

### Summary of Changes

### Testing Instructions

### Documentation Changes Required
