### PR TITLE
Change UTF8 decode to mbstring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,10 @@
     "homepage": "https://github.com/joomla-framework/uri",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^7.2.5|~8.0.0|~8.1.0",
-        "symfony/polyfill-mbstring": "^1.27"
+        "php": "^7.2.5|~8.0.0|~8.1.0|~8.2.0"
+    },
+    "suggest": {
+        "ext-mbstring": "Used to speed up url parsing"
     },
     "require-dev": {
         "joomla/coding-standards": "^3.0@dev",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "homepage": "https://github.com/joomla-framework/uri",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^7.2.5|~8.0.0|~8.1.0"
+        "php": "^7.2.5|~8.0.0|~8.1.0",
+        "symfony/polyfill-mbstring": "^1.27"
     },
     "require-dev": {
         "joomla/coding-standards": "^3.0@dev",

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -33,7 +33,7 @@ class UriHelper
 		$result = [];
 
 		// If no UTF-8 chars in the url just parse it using php native parse_url which is faster.
-		if (utf8_decode($url) === $url)
+		if (mb_convert_encoding($url, 'ISO-8859-1', 'UTF-8') === $url)
 		{
 			return parse_url($url, $component);
 		}

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -33,7 +33,7 @@ class UriHelper
 		$result = [];
 
 		// If no UTF-8 chars in the url just parse it using php native parse_url which is faster.
-		if (mb_convert_encoding($url, 'ISO-8859-1', 'UTF-8') === $url)
+		if (extension_loaded('mbstring') && mb_convert_encoding($url, 'ISO-8859-1', 'UTF-8') === $url)
 		{
 			return parse_url($url, $component);
 		}


### PR DESCRIPTION
Same as https://github.com/joomla/joomla-cms/pull/39583.

~Changes the UTF8 encoding to mbstring and does make the mbstring polyfill a dependency.~

Uses mb encoding to check if it is a normal url and adds the mb module as suggestion.